### PR TITLE
Add in-process log event bus and forward GameElement logs to console

### DIFF
--- a/.agents/skills/roguelike-feature/SKILL.md
+++ b/.agents/skills/roguelike-feature/SKILL.md
@@ -15,6 +15,7 @@ Identify which layer(s) the feature touches:
 - New input handling → `packages/game/lib/input/`
 - New visual output → `packages/game/lib/render/`
 - Canvas / DOM side effect → `packages/game/lib/effects/`
+- Logging or diagnostics side effect → `packages/game/lib/effects/` or the entry point, using `log()` from `@bruff/utils`
 - Reusable, domain-agnostic helper → `packages/utils/`
 
 ## 2 — Define action types
@@ -39,6 +40,8 @@ Use `InputAction` for normalised input, `GameAction` for simulation events, `Sys
 ## 4 — Wire up in the shell
 
 Add the new action to the root pipeline inside `effects/` or `loop.ts`. The shell dispatches to pure functions; it must contain no business logic itself.
+
+Shell diagnostics must emit through the logging event bus with `log()` from `@bruff/utils`. Do not add direct `console.*` calls.
 
 ## 5 — Gate check
 

--- a/.agents/skills/verify-layers/SKILL.md
+++ b/.agents/skills/verify-layers/SKILL.md
@@ -15,10 +15,12 @@ state/      — imports core/ only
 input/      — imports core/ + state/ only
 render/     — imports core/ + state/ only
 assets/     — imports core/ + state/ only
-effects/    — imports core/ + state/ only
+effects/    — shell wiring over core/state/input/render plus allowed workspace utilities
 ```
 
 No circular dependencies. No upward dependencies (e.g. `core/` must never import from `state/`).
+
+`@bruff/utils` imports are allowed from any layer for shared pure helpers and types. `log()` from `@bruff/utils` is shell-only: it may be imported by `effects/` or the entry point, but not by `core/`, `state/`, `input/`, or `render/`. Production code should not call `console.*` directly; console forwarding is handled by the logging event bus sink.
 
 ## How to Run
 
@@ -48,6 +50,8 @@ For each violation found, report:
 
 - [ ] No file in `core/` imports from any project path
 - [ ] No file in `state/` imports from `input/`, `render/`, `assets/`, or `effects/`
+- [ ] No file in `core/`, `state/`, `input/`, or `render/` imports `log` from `@bruff/utils`
+- [ ] No production file calls `console.*` outside the event-bus console sink
 - [ ] No circular imports anywhere
 - [ ] All `@bruff/utils` imports are allowed from any layer
 - [ ] All external package imports are only in the shell (`effects/`, entry point)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ These rules ensure maintainability, safety, and developer velocity.
 ##### Architecture Principles
 
 - **Functional Core, Imperative Shell** - All side effects (DOM, Canvas, I/O, logging) live in the shell; the core is pure and has no knowledge of the shell.
+- **Logging Through the Event Bus** - Production code emits logs with `log()` from `@bruff/utils`; direct `console.*` calls belong only in the event-bus console sink and tests.
 - **Command–Query Separation** - A function either returns a value (query) or produces a side effect (command), never both.
 - **Illegal States Unrepresentable** - Encode invariants in the type system (discriminated unions, branded types, refinement via narrowing) so impossible states cannot be expressed.
 - **Data-First Design** - Pass data through transformations; do not wrap data in objects with methods. State is plain records; behaviour is free functions.
@@ -212,7 +213,7 @@ The repo is a pnpm monorepo. Package-specific rules auto-load from `packages/<pa
 | `@bruff/game`          | Roguelike game logic — pure layered architecture (`core/state/input/render/effects`) | `.packages/game/AGENTS.override.md`         |
 | `@bruff/game-element`  | Imperative shell — Web Component base class that mounts the canvas                   | `.packages/game-element/AGENTS.override.md` |
 | `@bruff/arcade`        | E2E host — Vite app + Playwright tests across desktop/mobile browsers                | `.packages/arcade/AGENTS.override.md`       |
-| `@bruff/utils`         | Pure FP helpers (`pipe`, `clamp`, `hsla`, canvas utilities, etc.)                    | `.packages/utils/AGENTS.override.md`        |
+| `@bruff/utils`         | Shared utilities: pure FP helpers plus shell-adjacent browser/logging services       | `.packages/utils/AGENTS.override.md`        |
 | `@bruff/eslint-config` | Shared ESLint flat config                                                            | (none — config-only package)                |
 
 When working in a single package, also read its `README.md` for build/test commands and architectural role.

--- a/packages/game-element/AGENTS.override.md
+++ b/packages/game-element/AGENTS.override.md
@@ -1,9 +1,9 @@
 # `@bruff/game-element` — Imperative Shell
 
-This package is the **imperative shell** in the Functional Core / Imperative Shell pattern. It provides `GameElement`, the Web Component base class that mounts a full-viewport canvas inside an open shadow DOM.
+This package is the **imperative shell** in the Functional Core / Imperative Shell pattern. It provides `GameElement`, the Web Component base class that mounts a full-viewport canvas inside an open shadow DOM and forwards workspace log events to the browser console while connected.
 
 - **Language**: TypeScript with TSDoc annotations.
-- **Role**: The only place where shadow-DOM creation, canvas mounting, and Web Component lifecycle code lives. Pure game logic in `@bruff/game` consumes the canvas reference through this boundary and never touches the DOM directly.
+- **Role**: The only place where shadow-DOM creation, canvas mounting, log-bus console forwarding, and Web Component lifecycle code lives. Pure game logic in `@bruff/game` consumes the canvas reference through this boundary and never touches the DOM directly.
 
 ## Package-specific allowances
 
@@ -14,4 +14,5 @@ This package is the **imperative shell** in the Functional Core / Imperative She
 
 - **GE-3 (MUST)** `connectedCallback` is idempotent — calling it more than once must not recreate the shadow root.
 - **GE-4 (MUST)** Tests run in a real browser via Vitest + Playwright provider. Coverage thresholds are 100% for branches, functions, lines, and statements.
-- **GE-5 (MUST)** No game logic, no `GameState`, no actions, no rendering decisions. This package is purely structural — it exposes a canvas, nothing more.
+- **GE-5 (MUST)** No game logic, no `GameState`, no actions, no rendering decisions. This package is structural shell wiring only: it exposes a canvas and owns the lifecycle of the console log forwarding subscription.
+- **GE-6 (MUST)** `GameElement` subscribes to `onLog(consoleLogHandler)` idempotently in `connectedCallback` and unsubscribes in `disconnectedCallback`. Do not add direct `console.*` calls here; console output stays behind `consoleLogHandler` in `@bruff/utils`.

--- a/packages/game-element/README.md
+++ b/packages/game-element/README.md
@@ -79,3 +79,7 @@ pnpm run test:watch  # Watch mode
 ```
 
 Coverage thresholds are set at **100%** for branches, functions, lines, and statements.
+
+## Console log forwarding
+
+`GameElement` subscribes to `@bruff/utils` log events while connected. It forwards each event to the matching browser `console` method and unsubscribes in `disconnectedCallback`.

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,11 +1,10 @@
-import { log } from "@bruff/utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { log } from "@bruff/utils";
 
 import { GameElement } from "./game-element.js";
 
 const SINGLE_CALL = 1;
-const noop = (): void => void 0;
-
 const createGameElement = (): GameElement => {
   const element = document.createElement("bruff-game");
   if (!(element instanceof GameElement)) {
@@ -68,7 +67,7 @@ describe("GameElement structure", () => {
 
 describe("GameElement log forwarding", () => {
   it("forwards log events to the matching console method while connected", () => {
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(noop);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
 
     log({ level: "error", message: "boom" });
 
@@ -76,7 +75,7 @@ describe("GameElement log forwarding", () => {
   });
 
   it("stops forwarding after disconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(noop);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(vi.fn());
 
     log({ level: "info", message: "before" });
     const beforeDisconnectCalls = consoleInfoSpy.mock.calls.length;
@@ -87,7 +86,7 @@ describe("GameElement log forwarding", () => {
   });
 
   it("resubscribes after reconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(noop);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(vi.fn());
 
     gameElement.remove();
     document.body.append(gameElement);

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import { log } from "@bruff/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GameElement } from "./game-element.js";
 
 const SINGLE_CALL = 1;
+const noop = (): void => {};
 
 const createGameElement = (): GameElement => {
   const element = document.createElement("bruff-game");
@@ -35,16 +35,16 @@ const expectSingleCall = (spy: ReturnType<typeof vi.spyOn>): void => {
 // eslint-disable-next-line init-declarations
 let gameElement: GameElement;
 
-describe("GameElement", () => {
-  beforeEach(() => {
-    document.body.innerHTML = "";
-    gameElement = createConnectedGameElement();
-  });
+beforeEach(() => {
+  document.body.innerHTML = "";
+  gameElement = createConnectedGameElement();
+});
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
+describe("GameElement structure", () => {
   it("should be defined as a custom element", () => {
     expect(customElements.get("bruff-game")).toBeDefined();
   });
@@ -64,9 +64,11 @@ describe("GameElement", () => {
     gameElement.connectedCallback();
     expect(gameElement.shadowRoot).toBe(firstShadowRoot);
   });
+});
 
+describe("GameElement log forwarding", () => {
   it("forwards log events to the matching console method while connected", () => {
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(noop);
 
     log({ level: "error", message: "boom" });
 
@@ -74,7 +76,7 @@ describe("GameElement", () => {
   });
 
   it("stops forwarding after disconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(noop);
 
     log({ level: "info", message: "before" });
     const beforeDisconnectCalls = consoleInfoSpy.mock.calls.length;
@@ -85,7 +87,7 @@ describe("GameElement", () => {
   });
 
   it("resubscribes after reconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(noop);
 
     gameElement.remove();
     document.body.append(gameElement);

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,13 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import { log } from "@bruff/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GameElement } from "./game-element.js";
 
 const SINGLE_CALL = 1;
-const noop = (): void => {
-  return;
-};
+const noop = (): void => void 0;
 
 const createGameElement = (): GameElement => {
   const element = document.createElement("bruff-game");

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { log } from "@bruff/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameElement } from "./game-element.js";
 
 // eslint-disable-next-line init-declarations
@@ -6,22 +7,23 @@ let gameElement: GameElement;
 
 describe("GameElement", () => {
   beforeEach(() => {
-    // Clean up any previous elements
     document.body.innerHTML = "";
 
-    // Register custom element if not already registered
     if (!customElements.get("bruff-game")) {
       // eslint-disable-next-line wc/tag-name-matches-class
       customElements.define("bruff-game", GameElement);
     }
 
-    // Create fresh game element for each test
     const element = document.createElement("bruff-game");
     if (!(element instanceof GameElement)) {
       throw new TypeError("Failed to create GameElement");
     }
     gameElement = element;
     document.body.append(gameElement);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should be defined as a custom element", () => {
@@ -37,13 +39,46 @@ describe("GameElement", () => {
   });
 
   it("should not recreate shadow root if one already exists", () => {
-    // The connectedCallback is called automatically when appended to the DOM.
-    // Calling it again to test the guard clause.
     gameElement.connectedCallback();
     expect(gameElement.shadowRoot).toBeDefined();
     const firstShadowRoot = gameElement.shadowRoot;
     gameElement.connectedCallback();
     expect(gameElement.shadowRoot).toBe(firstShadowRoot);
+  });
+
+  it("forwards log events to the matching console method while connected", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    log({ level: "error", message: "boom" });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops forwarding after disconnect", () => {
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    log({ level: "info", message: "before" });
+    const beforeDisconnectCalls = consoleInfo.mock.calls.length;
+    gameElement.remove();
+    log({ level: "info", message: "after" });
+
+    expect(consoleInfo.mock.calls.length).toBe(beforeDisconnectCalls);
+  });
+
+  it("resubscribes after reconnect", () => {
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    gameElement.remove();
+    document.body.append(gameElement);
+    log({ level: "info", message: "again" });
+
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnectedCallback is a no-op before first connect", () => {
+    const detachedElement = new GameElement();
+
+    expect(() => detachedElement.disconnectedCallback()).not.toThrow();
   });
 });
 
@@ -58,7 +93,6 @@ const mockStencilError = (templateElement: HTMLTemplateElement): void => {
     return realCreateElement(tagName);
   });
 
-  // Use a real div as it's a Node but not a DocumentFragment
   const invalidNode = realCreateElement("div");
   vi.spyOn(templateElement.content, "cloneNode").mockReturnValue(invalidNode);
 };
@@ -69,9 +103,7 @@ describe("GameElement Error Cases", () => {
     GameElement.template = (): string => "<div>No template here</div>";
     const element = new GameElement();
     expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow(
-      "Template element not found",
-    );
+    expect(() => element.connectedCallback()).toThrow("Template element not found");
     GameElement.template = originalTemplate;
   });
 
@@ -84,9 +116,7 @@ describe("GameElement Error Cases", () => {
     mockStencilError(templateElement);
 
     expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow(
-      "Failed to clone template",
-    );
+    expect(() => element.connectedCallback()).toThrow("Failed to clone template");
 
     vi.restoreAllMocks();
     GameElement.template = originalTemplate;

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -29,6 +29,16 @@ const expectSingleCall = (spy: ReturnType<typeof vi.spyOn>): void => {
   expect(spy).toHaveBeenCalledTimes(SINGLE_CALL);
 };
 
+const getConnectedCallbackError = (element: GameElement): unknown => {
+  try {
+    element.connectedCallback();
+  } catch (error: unknown) {
+    return error;
+  }
+
+  return null;
+};
+
 // eslint-disable-next-line init-declarations
 let gameElement: GameElement;
 
@@ -126,10 +136,10 @@ describe("GameElement Error Cases", () => {
     const originalTemplate = GameElement.template;
     GameElement.template = (): string => "<div>No template here</div>";
     const element = new GameElement();
-    expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow(
-      "Template element not found",
-    );
+    const error = getConnectedCallbackError(element);
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).toHaveProperty("message", "Template element not found");
     GameElement.template = originalTemplate;
   });
 
@@ -141,10 +151,10 @@ describe("GameElement Error Cases", () => {
 
     mockStencilError(templateElement);
 
-    expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow(
-      "Failed to clone template",
-    );
+    const error = getConnectedCallbackError(element);
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).toHaveProperty("message", "Failed to clone template");
 
     vi.restoreAllMocks();
     GameElement.template = originalTemplate;

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { log } from "@bruff/utils";
-
 import { GameElement } from "./game-element.js";
+import { log } from "@bruff/utils";
 
 const SINGLE_CALL = 1;
 const createGameElement = (): GameElement => {
@@ -67,7 +65,9 @@ describe("GameElement structure", () => {
 
 describe("GameElement log forwarding", () => {
   it("forwards log events to the matching console method while connected", () => {
-    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(vi.fn());
 
     log({ level: "error", message: "boom" });
 
@@ -75,7 +75,9 @@ describe("GameElement log forwarding", () => {
   });
 
   it("stops forwarding after disconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(vi.fn());
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(vi.fn());
 
     log({ level: "info", message: "before" });
     const beforeDisconnectCalls = consoleInfoSpy.mock.calls.length;
@@ -86,7 +88,9 @@ describe("GameElement log forwarding", () => {
   });
 
   it("resubscribes after reconnect", () => {
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(vi.fn());
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(vi.fn());
 
     gameElement.remove();
     document.body.append(gameElement);
@@ -123,7 +127,9 @@ describe("GameElement Error Cases", () => {
     GameElement.template = (): string => "<div>No template here</div>";
     const element = new GameElement();
     expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow("Template element not found");
+    expect(() => element.connectedCallback()).toThrow(
+      "Template element not found",
+    );
     GameElement.template = originalTemplate;
   });
 
@@ -136,7 +142,9 @@ describe("GameElement Error Cases", () => {
     mockStencilError(templateElement);
 
     expect(() => element.connectedCallback()).toThrow(TypeError);
-    expect(() => element.connectedCallback()).toThrow("Failed to clone template");
+    expect(() => element.connectedCallback()).toThrow(
+      "Failed to clone template",
+    );
 
     vi.restoreAllMocks();
     GameElement.template = originalTemplate;

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,6 +1,36 @@
-import { log } from "@bruff/utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { log } from "@bruff/utils";
+
 import { GameElement } from "./game-element.js";
+
+const SINGLE_CALL = 1;
+
+const createGameElement = (): GameElement => {
+  const element = document.createElement("bruff-game");
+  if (!(element instanceof GameElement)) {
+    throw new TypeError("Failed to create GameElement");
+  }
+  return element;
+};
+
+const registerGameElement = (): void => {
+  if (!customElements.get("bruff-game")) {
+    // eslint-disable-next-line wc/tag-name-matches-class
+    customElements.define("bruff-game", GameElement);
+  }
+};
+
+const createConnectedGameElement = (): GameElement => {
+  registerGameElement();
+  const element = createGameElement();
+  document.body.append(element);
+  return element;
+};
+
+const expectSingleCall = (spy: ReturnType<typeof vi.spyOn>): void => {
+  expect(spy).toHaveBeenCalledTimes(SINGLE_CALL);
+};
 
 // eslint-disable-next-line init-declarations
 let gameElement: GameElement;
@@ -8,18 +38,7 @@ let gameElement: GameElement;
 describe("GameElement", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
-
-    if (!customElements.get("bruff-game")) {
-      // eslint-disable-next-line wc/tag-name-matches-class
-      customElements.define("bruff-game", GameElement);
-    }
-
-    const element = document.createElement("bruff-game");
-    if (!(element instanceof GameElement)) {
-      throw new TypeError("Failed to create GameElement");
-    }
-    gameElement = element;
-    document.body.append(gameElement);
+    gameElement = createConnectedGameElement();
   });
 
   afterEach(() => {
@@ -47,32 +66,32 @@ describe("GameElement", () => {
   });
 
   it("forwards log events to the matching console method while connected", () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     log({ level: "error", message: "boom" });
 
-    expect(consoleError).toHaveBeenCalledTimes(1);
+    expectSingleCall(consoleErrorSpy);
   });
 
   it("stops forwarding after disconnect", () => {
-    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
 
     log({ level: "info", message: "before" });
-    const beforeDisconnectCalls = consoleInfo.mock.calls.length;
+    const beforeDisconnectCalls = consoleInfoSpy.mock.calls.length;
     gameElement.remove();
     log({ level: "info", message: "after" });
 
-    expect(consoleInfo.mock.calls.length).toBe(beforeDisconnectCalls);
+    expect(consoleInfoSpy.mock.calls.length).toBe(beforeDisconnectCalls);
   });
 
   it("resubscribes after reconnect", () => {
-    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
 
     gameElement.remove();
     document.body.append(gameElement);
     log({ level: "info", message: "again" });
 
-    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expectSingleCall(consoleInfoSpy);
   });
 
   it("disconnectedCallback is a no-op before first connect", () => {

--- a/packages/game-element/module/game-element.test.ts
+++ b/packages/game-element/module/game-element.test.ts
@@ -1,10 +1,13 @@
-import { log } from "@bruff/utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { log } from "@bruff/utils";
 
 import { GameElement } from "./game-element.js";
 
 const SINGLE_CALL = 1;
-const noop = (): void => {};
+const noop = (): void => {
+  return;
+};
 
 const createGameElement = (): GameElement => {
   const element = document.createElement("bruff-game");

--- a/packages/game-element/module/game-element.ts
+++ b/packages/game-element/module/game-element.ts
@@ -1,8 +1,12 @@
+import { consoleLogHandler, onLog } from "@bruff/utils";
+
 /**
  * A class to represent a game web component
  */
 // eslint-disable-next-line wc/define-tag-after-class-definition
 export class GameElement extends HTMLElement {
+  #unsubscribe?: () => void;
+
   /**
    * Lifecycle callback when the element is added to the document's DOM.
    * Creates and initializes the shadow DOM if it doesn't exist.
@@ -21,6 +25,15 @@ export class GameElement extends HTMLElement {
       }
       this.attachShadow({ mode: "open" }).append(stencil);
     }
+
+    if (this.#unsubscribe === undefined) {
+      this.#unsubscribe = onLog(consoleLogHandler);
+    }
+  }
+
+  disconnectedCallback(): void {
+    this.#unsubscribe?.();
+    this.#unsubscribe = undefined;
   }
 
   /**

--- a/packages/game-element/module/game-element.ts
+++ b/packages/game-element/module/game-element.ts
@@ -23,7 +23,9 @@ export class GameElement extends HTMLElement {
 
   connectedCallback(): void {
     if (!this.shadowRoot) {
-      this.attachShadow({ mode: "open" }).append(createStencil(GameElement.template()));
+      this.attachShadow({ mode: "open" }).append(
+        createStencil(GameElement.template()),
+      );
     }
 
     if (this.#unsubscribe === undefined) {

--- a/packages/game-element/module/game-element.ts
+++ b/packages/game-element/module/game-element.ts
@@ -1,8 +1,8 @@
 import { consoleLogHandler, onLog } from "@bruff/utils";
 
-const initializeShadowRoot = (element: GameElement): void => {
+const createStencil = (templateMarkup: string): DocumentFragment => {
   const wrapper = document.createElement("div");
-  wrapper.innerHTML = GameElement.template();
+  wrapper.innerHTML = templateMarkup;
   const template = wrapper.querySelector("template");
   if (!(template instanceof HTMLTemplateElement)) {
     throw new TypeError("Template element not found");
@@ -11,7 +11,7 @@ const initializeShadowRoot = (element: GameElement): void => {
   if (!(stencil instanceof DocumentFragment)) {
     throw new TypeError("Failed to clone template");
   }
-  element.attachShadow({ mode: "open" }).append(stencil);
+  return stencil;
 };
 
 /**
@@ -21,13 +21,9 @@ const initializeShadowRoot = (element: GameElement): void => {
 export class GameElement extends HTMLElement {
   #unsubscribe?: () => void;
 
-  /**
-   * Lifecycle callback when the element is added to the document's DOM.
-   * Creates and initializes the shadow DOM if it doesn't exist.
-   */
   connectedCallback(): void {
     if (!this.shadowRoot) {
-      initializeShadowRoot(this);
+      this.attachShadow({ mode: "open" }).append(createStencil(GameElement.template()));
     }
 
     if (this.#unsubscribe === undefined) {

--- a/packages/game-element/module/game-element.ts
+++ b/packages/game-element/module/game-element.ts
@@ -19,7 +19,7 @@ const createStencil = (templateMarkup: string): DocumentFragment => {
  */
 // eslint-disable-next-line wc/define-tag-after-class-definition
 export class GameElement extends HTMLElement {
-  #unsubscribe?: () => void;
+  #unsubscribe: (() => void) | undefined;
 
   connectedCallback(): void {
     if (!this.shadowRoot) {

--- a/packages/game-element/module/game-element.ts
+++ b/packages/game-element/module/game-element.ts
@@ -1,5 +1,19 @@
 import { consoleLogHandler, onLog } from "@bruff/utils";
 
+const initializeShadowRoot = (element: GameElement): void => {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = GameElement.template();
+  const template = wrapper.querySelector("template");
+  if (!(template instanceof HTMLTemplateElement)) {
+    throw new TypeError("Template element not found");
+  }
+  const stencil = template.content.cloneNode(true);
+  if (!(stencil instanceof DocumentFragment)) {
+    throw new TypeError("Failed to clone template");
+  }
+  element.attachShadow({ mode: "open" }).append(stencil);
+};
+
 /**
  * A class to represent a game web component
  */
@@ -13,17 +27,7 @@ export class GameElement extends HTMLElement {
    */
   connectedCallback(): void {
     if (!this.shadowRoot) {
-      const wrapper = document.createElement("div");
-      wrapper.innerHTML = GameElement.template();
-      const template = wrapper.querySelector("template");
-      if (!(template instanceof HTMLTemplateElement)) {
-        throw new TypeError("Template element not found");
-      }
-      const stencil = template.content.cloneNode(true);
-      if (!(stencil instanceof DocumentFragment)) {
-        throw new TypeError("Failed to clone template");
-      }
-      this.attachShadow({ mode: "open" }).append(stencil);
+      initializeShadowRoot(this);
     }
 
     if (this.#unsubscribe === undefined) {
@@ -36,11 +40,6 @@ export class GameElement extends HTMLElement {
     this.#unsubscribe = undefined;
   }
 
-  /**
-   * Generates an HTML template string for the game component.
-   *
-   * @returns The template string
-   */
   static template(): string {
     const width = window.innerWidth;
     const height = window.innerHeight;

--- a/packages/game-element/package.json
+++ b/packages/game-element/package.json
@@ -26,5 +26,8 @@
     "rimraf": "6.1.3",
     "typescript": "5.9.3",
     "vitest": "4.1.4"
+  },
+  "dependencies": {
+    "@bruff/utils": "workspace:0.0.0"
   }
 }

--- a/packages/game/AGENTS.override.md
+++ b/packages/game/AGENTS.override.md
@@ -9,25 +9,27 @@ This package contains the core game logic. The rules below apply to every file u
 
 Code must live in the correct layer. Dependencies flow strictly inward — later layers may depend on earlier ones but inner layers must never import outer layers, and no circular dependencies are allowed.
 
-| Layer   | Location                     | May import from   |
-| ------- | ---------------------------- | ----------------- |
-| Core    | `packages/game/lib/core/`    | Nothing           |
-| State   | `packages/game/lib/state/`   | `core/` only      |
-| Input   | `packages/game/lib/input/`   | `core/`, `state/` |
-| Render  | `packages/game/lib/render/`  | `core/`, `state/` |
-| Effects | `packages/game/lib/effects/` | `core/`, `state/` |
+`@bruff/utils` imports are allowed where they provide shared pure helpers or shell services. The `log()` event-bus helper is shell-only: use it from `effects/` or the entry point, never from `core/`, `state/`, `input/`, or `render/`.
+
+| Layer   | Location                     | May import from                                    |
+| ------- | ---------------------------- | -------------------------------------------------- |
+| Core    | `packages/game/lib/core/`    | Nothing except shared `@bruff/utils` types/helpers |
+| State   | `packages/game/lib/state/`   | `core/`, shared `@bruff/utils` helpers             |
+| Input   | `packages/game/lib/input/`   | `core/`, `state/`, shared `@bruff/utils` helpers   |
+| Render  | `packages/game/lib/render/`  | `core/`, `state/`, shared `@bruff/utils` helpers   |
+| Effects | `packages/game/lib/effects/` | Shell wiring over inner layers and `@bruff/utils`  |
 
 ### Dependency Rules
 
 - **A-1 (MUST)** `core/` must have zero imports.
 - **A-2 (MUST)** No circular dependencies.
-- **A-3 (MUST)** Side effects (Canvas, DOM, I/O) live only in `effects/`.
+- **A-3 (MUST)** Side effects (Canvas, DOM, I/O, logging emission) live only in `effects/` or the entry point.
 - **A-4 (MUST)** Dependencies flow inward toward `core/` only.
 
 ## Pure Core / Impure Shell
 
 - **A-5 (MUST)** All game logic (`core/`, `state/`, `input/`, `render/`) is pure: no DOM access, no `fetch`, no `Math.random()`, no `Date.now()`.
-- **A-6 (MUST)** All side effects (Canvas draws, event listeners, timers) live in `effects/` or the entry point only.
+- **A-6 (MUST)** All side effects (Canvas draws, event listeners, timers, logging emission) live in `effects/` or the entry point only. Emit production logs through `log()` from `@bruff/utils`; do not call `console.*` directly in `packages/game`.
 
 ## State & Immutability
 

--- a/packages/game/lib/effects/entry.test.ts
+++ b/packages/game/lib/effects/entry.test.ts
@@ -1,0 +1,38 @@
+import type * as Utilities from "@bruff/utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { log } from "@bruff/utils";
+import loop from "./loop.js";
+
+vi.mock("@bruff/utils", async (importOriginal) => {
+  const original = await importOriginal<typeof Utilities>();
+  return {
+    ...original,
+    log: vi.fn(),
+  };
+});
+
+vi.mock("./loop.js", () => ({
+  default: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+describe("entry", () => {
+  it("registers the game element and logs through the event bus", async () => {
+    vi.stubGlobal("__APP_VERSION__", "0.0.0");
+
+    await import("./entry.js");
+
+    expect(customElements.get("bruff-game")).toBeDefined();
+    expect(log).toHaveBeenCalledWith({
+      level: "info",
+      message: "bruff game v0.0.0 was defined",
+      source: "@bruff/game/effects/entry",
+    });
+    expect(loop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/game/lib/effects/entry.ts
+++ b/packages/game/lib/effects/entry.ts
@@ -1,10 +1,15 @@
 import { GameElement } from "@bruff/game-element";
+import { log } from "@bruff/utils";
 import loop from "./loop.js";
 
 if (!customElements.get("bruff-game")) {
   // eslint-disable-next-line wc/tag-name-matches-class -- GameElement is the generic shell class registered under the application-specific bruff-game tag; the class:tag mapping convention does not apply.
   customElements.define("bruff-game", GameElement);
-  console.info(`bruff game v${__APP_VERSION__} was defined`);
+  log({
+    level: "info",
+    message: `bruff game v${__APP_VERSION__} was defined`,
+    source: "@bruff/game/effects/entry",
+  });
 }
 
 loop();

--- a/packages/game/lib/effects/loop.test.ts
+++ b/packages/game/lib/effects/loop.test.ts
@@ -1,0 +1,88 @@
+import type * as Utilities from "@bruff/utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { error, log, ok } from "@bruff/utils";
+import createTouchObservable from "./observable/touch.js";
+import curtainUp from "./curtain-up.js";
+import type { InputAction } from "../core/actions.ts";
+import loop from "./loop.js";
+import type { Observable } from "observable-polyfill/fn";
+
+vi.mock("@bruff/utils", async (importOriginal) => {
+  const original = await importOriginal<typeof Utilities>();
+  return {
+    ...original,
+    log: vi.fn(),
+    radiatingBarsBackgroundAnimation: vi.fn(),
+  };
+});
+
+vi.mock("./curtain-up.js", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("./observable/touch.js", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("./render.js", () => ({
+  default: vi.fn(),
+}));
+
+const createActionObservable = (eventName: string): Observable<InputAction> =>
+  document.when(eventName).map((): InputAction => ({ type: "move-up" }));
+
+const createPreparedCanvas = (): {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+} => {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  if (context === null) {
+    throw new TypeError("Could not create canvas context");
+  }
+  return { canvas, context };
+};
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("loop logging", () => {
+  it("emits setup failures through the event bus", () => {
+    vi.mocked(curtainUp).mockReturnValue(error("canvas-not-found"));
+
+    loop();
+
+    expect(log).toHaveBeenCalledWith({
+      context: { error: "canvas-not-found" },
+      level: "error",
+      message: "setup failed",
+      source: "@bruff/game/effects/loop",
+    });
+  });
+
+  it("emits touch input through the event bus", () => {
+    const { canvas, context } = createPreparedCanvas();
+    vi.mocked(curtainUp).mockReturnValue(
+      ok({ canvas, context, removeCanvasResizeListener: vi.fn() }),
+    );
+    vi.mocked(createTouchObservable).mockReturnValue(
+      createActionObservable("bruff-test-touch-action"),
+    );
+
+    loop();
+    document.dispatchEvent(new Event("bruff-test-touch-action"));
+
+    expect(log).toHaveBeenCalledWith({
+      context: { actionType: "move-up" },
+      level: "info",
+      message: "touch",
+      source: "@bruff/game/effects/loop",
+    });
+  });
+});

--- a/packages/game/lib/effects/loop.ts
+++ b/packages/game/lib/effects/loop.ts
@@ -1,11 +1,11 @@
 import { apply, isSupported, type Observable } from "observable-polyfill/fn";
 import type { GameAction, InputAction } from "../core/actions.ts";
+import { log, radiatingBarsBackgroundAnimation } from "@bruff/utils";
 import createInitialState from "../state/create-initial-state.js";
 import createKeyDownObservable from "./observable/keydown.js";
 import createTouchObservable from "./observable/touch.js";
 import curtainUp from "./curtain-up.js";
 import type { GameState } from "../core/types.ts";
-import { radiatingBarsBackgroundAnimation } from "@bruff/utils";
 import render from "./render.js";
 import { updateEnemies } from "../state/update-enemies.js";
 import updatePlayer from "../state/update-player.js";
@@ -105,7 +105,12 @@ const subscribeToGameObservables = (
   keyObservable$.subscribe(onInput);
   touchObservable$.subscribe(onInput);
   touchObservable$.subscribe((action: InputAction) => {
-    console.info("touch:", action.type);
+    log({
+      context: { actionType: action.type },
+      level: "info",
+      message: "touch",
+      source: "@bruff/game/effects/loop",
+    });
   });
 };
 
@@ -156,7 +161,12 @@ const buildRenderFrame =
 const loop = (): void => {
   const stageResult = curtainUp();
   if (stageResult.type === "error") {
-    console.error(`bruff: setup failed (${stageResult.error})`);
+    log({
+      context: { error: stageResult.error },
+      level: "error",
+      message: "setup failed",
+      source: "@bruff/game/effects/loop",
+    });
     return;
   }
   const { canvas, context, removeCanvasResizeListener } = stageResult.value;

--- a/packages/game/lib/effects/observable/keydown.test.ts
+++ b/packages/game/lib/effects/observable/keydown.test.ts
@@ -17,4 +17,14 @@ describe("createKeyDownObservable", () => {
 
     expect(next).toHaveBeenCalledWith({ type: "move-up" });
   });
+
+  it("ignores non-keyboard keydown events", () => {
+    const keyDown$ = createKeyDownObservable();
+    const next = vi.fn();
+    keyDown$.subscribe(next);
+
+    document.dispatchEvent(new Event("keydown"));
+
+    expect(next).not.toHaveBeenCalled();
+  });
 });

--- a/packages/utils/AGENTS.override.md
+++ b/packages/utils/AGENTS.override.md
@@ -1,8 +1,14 @@
 # `@bruff/utils`
 
-This package contains shared, reusable utility functions.
+This package contains shared, reusable utilities.
 
 - **Language**: **TypeScript**.
-- **Purpose**: To house generic, pure functions (e.g., data manipulation, math helpers) that can be used across the entire project or even in other projects.
+- **Purpose**: To house generic pure functions (e.g., data manipulation, math helpers) and small shell-adjacent browser services that are reusable across the workspace.
 - **Typing**: While using `.ts` files, all type information **must be declared using TSDoc annotations**.
 - **Style**: Must adhere to the "double quotes" and "two-space indentation" rule.
+
+## Logging Event Bus
+
+- **U-1 (MUST)** Production logging flows through `module/event-bus/`. Export `log()` / `onLog()` for emitters and subscribers; do not expose the private transport.
+- **U-2 (MUST)** `consoleLogHandler` is the only production utility that calls `console.*`. Other utilities emit log events with `log()`.
+- **U-3 (MUST)** Pure helpers must stay pure. Only shell-adjacent utilities may emit log events.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -89,3 +89,13 @@ pnpm run test                    # Chromium, Firefox, WebKit with coverage
 pnpm run test:chromium           # Single browser
 pnpm run test:watch              # Watch mode
 ```
+
+## Event bus
+
+`@bruff/utils` provides a process-local log event bus:
+
+- `log(event)` emits a log event with `level`, `message`, and optional `source`/`context`.
+- `onLog(handler)` subscribes to log events and returns an unsubscribe function.
+- `consoleLogHandler(event)` forwards a log event to the matching `console` method.
+- `LogLevel` is one of `"debug" | "info" | "warn" | "error"`.
+- `LogEvent` is the readonly payload type emitted and consumed by the log bus.

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,3 +1,7 @@
+export { consoleLogHandler } from "./module/event-bus/console-log-handler.js";
+export { log, onLog } from "./module/event-bus/event-bus.js";
+export type { LogEvent } from "./module/event-bus/log-event.js";
+export type { LogLevel } from "./module/event-bus/log-level.js";
 export { canvasResizeListener } from "./module/canvas/canvas-resize-listener.js";
 export { createCanvasResizeObserver } from "./module/canvas/create-canvas-resize-observer.js";
 export { getCanvas } from "./module/canvas/get-canvas.js";

--- a/packages/utils/module/canvas/canvas-resize-listener.test.ts
+++ b/packages/utils/module/canvas/canvas-resize-listener.test.ts
@@ -1,29 +1,38 @@
 import { afterEach, expect, test, vi } from "vitest";
 import { canvasResizeListener } from "./canvas-resize-listener.js";
+import { onLog } from "../event-bus/event-bus.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("#canvasResizeListener adds an event listener that logs to console", () => {
+test("#canvasResizeListener adds an event listener that emits a log event", () => {
   const canvas = document.createElement("canvas");
-  vi.spyOn(console, "info").mockImplementation(() => {
-    // Do nothing
-  });
+  const handler = vi.fn();
+  const cleanupLog = onLog(handler);
+
   canvasResizeListener(canvas);
   const event = new CustomEvent("elementResized");
   canvas.dispatchEvent(event);
-  expect(console.info).toHaveBeenCalledWith("elementResized");
+
+  expect(handler).toHaveBeenCalledWith({
+    level: "info",
+    message: "elementResized",
+    source: "@bruff/utils/canvas",
+  });
+  cleanupLog();
 });
 
 test("#canvasResizeListener returns a cleanup function that removes the event listener", () => {
   const canvas = document.createElement("canvas");
-  vi.spyOn(console, "info").mockImplementation(() => {
-    // Do nothing
-  });
+  const handler = vi.fn();
+  const cleanupLog = onLog(handler);
   const cleanup = canvasResizeListener(canvas);
+
   cleanup();
   const event = new CustomEvent("elementResized");
   canvas.dispatchEvent(event);
-  expect(console.info).not.toHaveBeenCalled();
+
+  expect(handler).not.toHaveBeenCalled();
+  cleanupLog();
 });

--- a/packages/utils/module/canvas/canvas-resize-listener.ts
+++ b/packages/utils/module/canvas/canvas-resize-listener.ts
@@ -1,10 +1,16 @@
+import { log } from "../event-bus/event-bus.js";
+
 /**
  * Logs that the element has been resized
  *
  * @returns void
  */
 const logInfo = (): void => {
-  console.info("elementResized");
+  log({
+    level: "info",
+    message: "elementResized",
+    source: "@bruff/utils/canvas",
+  });
 };
 
 /**

--- a/packages/utils/module/event-bus/console-log-handler.test.ts
+++ b/packages/utils/module/event-bus/console-log-handler.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { consoleLogHandler } from "./console-log-handler";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("consoleLogHandler", () => {
+  it.each(["debug", "info", "warn", "error"] as const)("routes %s level to matching console method", (level) => {
+    const spy = vi.spyOn(console, level).mockImplementation(() => undefined);
+
+    consoleLogHandler({ level, message: "m" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs only prefix and message when source and context are absent", () => {
+    const spy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    consoleLogHandler({ level: "info", message: "m" });
+
+    expect(spy).toHaveBeenCalledWith("[info]", "m");
+  });
+
+  it("includes source and context when both are present", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    consoleLogHandler({
+      level: "warn",
+      message: "m",
+      source: "unit",
+      context: { id: 1 },
+    });
+
+    expect(spy).toHaveBeenCalledWith("[warn]", "m", {
+      source: "unit",
+      context: { id: 1 },
+    });
+  });
+});

--- a/packages/utils/module/event-bus/console-log-handler.test.ts
+++ b/packages/utils/module/event-bus/console-log-handler.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { consoleLogHandler } from "./console-log-handler";
 
+const EXPECTED_CALL_COUNT = 1;
+const CONTEXT_ID = 1;
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -10,16 +13,16 @@ describe("consoleLogHandler", () => {
   it.each(["debug", "info", "warn", "error"] as const)(
     "routes %s level to matching console method",
     (level) => {
-      const spy = vi.spyOn(console, level).mockImplementation(() => undefined);
+      const spy = vi.spyOn(console, level).mockImplementation(() => true);
 
       consoleLogHandler({ level, message: "m" });
 
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(EXPECTED_CALL_COUNT);
     },
   );
 
   it("logs only prefix and message when source and context are absent", () => {
-    const spy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const spy = vi.spyOn(console, "info").mockImplementation(() => true);
 
     consoleLogHandler({ level: "info", message: "m" });
 
@@ -27,18 +30,18 @@ describe("consoleLogHandler", () => {
   });
 
   it("includes source and context when both are present", () => {
-    const spy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => true);
 
     consoleLogHandler({
+      context: { id: CONTEXT_ID },
       level: "warn",
       message: "m",
       source: "unit",
-      context: { id: 1 },
     });
 
     expect(spy).toHaveBeenCalledWith("[warn]", "m", {
+      context: { id: CONTEXT_ID },
       source: "unit",
-      context: { id: 1 },
     });
   });
 });

--- a/packages/utils/module/event-bus/console-log-handler.test.ts
+++ b/packages/utils/module/event-bus/console-log-handler.test.ts
@@ -7,13 +7,16 @@ afterEach(() => {
 });
 
 describe("consoleLogHandler", () => {
-  it.each(["debug", "info", "warn", "error"] as const)("routes %s level to matching console method", (level) => {
-    const spy = vi.spyOn(console, level).mockImplementation(() => undefined);
+  it.each(["debug", "info", "warn", "error"] as const)(
+    "routes %s level to matching console method",
+    (level) => {
+      const spy = vi.spyOn(console, level).mockImplementation(() => undefined);
 
-    consoleLogHandler({ level, message: "m" });
+      consoleLogHandler({ level, message: "m" });
 
-    expect(spy).toHaveBeenCalledTimes(1);
-  });
+      expect(spy).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("logs only prefix and message when source and context are absent", () => {
     const spy = vi.spyOn(console, "info").mockImplementation(() => undefined);

--- a/packages/utils/module/event-bus/console-log-handler.ts
+++ b/packages/utils/module/event-bus/console-log-handler.ts
@@ -1,18 +1,26 @@
 import type { LogEvent } from "./log-event";
 import type { LogLevel } from "./log-level";
 
-const getConsoleMethod = (level: LogLevel): typeof console.debug => {
-  switch (level) {
-    case "debug":
-      return console.debug;
-    case "info":
-      return console.info;
-    case "warn":
-      return console.warn;
-    case "error":
-      return console.error;
-  }
-};
+type ConsoleLogSink = (...messages: ReadonlyArray<unknown>) => void;
+
+const consoleMethods = {
+  debug: (...messages: ReadonlyArray<unknown>): void => {
+    // eslint-disable-next-line no-console -- Debug log events intentionally route to the matching console method.
+    console.debug(...messages);
+  },
+  error: (...messages: ReadonlyArray<unknown>): void => {
+    console.error(...messages);
+  },
+  info: (...messages: ReadonlyArray<unknown>): void => {
+    console.info(...messages);
+  },
+  warn: (...messages: ReadonlyArray<unknown>): void => {
+    console.warn(...messages);
+  },
+} satisfies Readonly<Record<LogLevel, ConsoleLogSink>>;
+
+const getConsoleMethod = (level: LogLevel): ConsoleLogSink =>
+  consoleMethods[level];
 
 const getPrefix = (level: LogLevel): string => `[${level}]`;
 
@@ -28,5 +36,5 @@ export const consoleLogHandler = (event: LogEvent): void => {
     return;
   }
 
-  sink(prefix, event.message, { source: event.source, context: event.context });
+  sink(prefix, event.message, { context: event.context, source: event.source });
 };

--- a/packages/utils/module/event-bus/console-log-handler.ts
+++ b/packages/utils/module/event-bus/console-log-handler.ts
@@ -1,0 +1,32 @@
+import type { LogEvent } from "./log-event";
+import type { LogLevel } from "./log-level";
+
+const getConsoleMethod = (level: LogLevel): typeof console.debug => {
+  switch (level) {
+    case "debug":
+      return console.debug;
+    case "info":
+      return console.info;
+    case "warn":
+      return console.warn;
+    case "error":
+      return console.error;
+  }
+};
+
+const getPrefix = (level: LogLevel): string => `[${level}]`;
+
+/**
+ * Writes a log event to the browser console.
+ */
+export const consoleLogHandler = (event: LogEvent): void => {
+  const sink = getConsoleMethod(event.level);
+  const prefix = getPrefix(event.level);
+
+  if (event.source === undefined && event.context === undefined) {
+    sink(prefix, event.message);
+    return;
+  }
+
+  sink(prefix, event.message, { source: event.source, context: event.context });
+};

--- a/packages/utils/module/event-bus/event-bus.test.ts
+++ b/packages/utils/module/event-bus/event-bus.test.ts
@@ -11,7 +11,12 @@ describe("event-bus", () => {
   it("delivers the exact event to a single subscriber", () => {
     const handler = vi.fn();
     const cleanup = onLog(handler);
-    const event = { level: "warn", message: "hello", source: "test", context: { id: 1 } } as const;
+    const event = {
+      level: "warn",
+      message: "hello",
+      source: "test",
+      context: { id: 1 },
+    } as const;
 
     log(event);
 
@@ -41,7 +46,9 @@ describe("event-bus", () => {
 
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
-    expect(first.mock.invocationCallOrder[0]).toBeLessThan(second.mock.invocationCallOrder[0]);
+    expect(first.mock.invocationCallOrder[0]).toBeLessThan(
+      second.mock.invocationCallOrder[0],
+    );
 
     cleanupFirst();
     cleanupSecond();

--- a/packages/utils/module/event-bus/event-bus.test.ts
+++ b/packages/utils/module/event-bus/event-bus.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { log, onLog } from "./event-bus";
+
+describe("event-bus", () => {
+  it("returns undefined and does not throw when no subscribers exist", () => {
+    expect(() => log({ level: "info", message: "noop" })).not.toThrow();
+    expect(log({ level: "info", message: "noop-2" })).toBeUndefined();
+  });
+
+  it("delivers the exact event to a single subscriber", () => {
+    const handler = vi.fn();
+    const cleanup = onLog(handler);
+    const event = { level: "warn", message: "hello", source: "test", context: { id: 1 } } as const;
+
+    log(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(event);
+    cleanup();
+  });
+
+  it("stops delivery after unsubscribe", () => {
+    const handler = vi.fn();
+    const cleanup = onLog(handler);
+
+    log({ level: "info", message: "one" });
+    cleanup();
+    log({ level: "info", message: "two" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers events in registration order", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const cleanupFirst = onLog(first);
+    const cleanupSecond = onLog(second);
+
+    log({ level: "info", message: "x" });
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first.mock.invocationCallOrder[0]).toBeLessThan(second.mock.invocationCallOrder[0]);
+
+    cleanupFirst();
+    cleanupSecond();
+  });
+
+  it("supports idempotent double-unsubscribe", () => {
+    const handler = vi.fn();
+    const cleanup = onLog(handler);
+
+    cleanup();
+    cleanup();
+    log({ level: "error", message: "ignored" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/utils/module/event-bus/event-bus.test.ts
+++ b/packages/utils/module/event-bus/event-bus.test.ts
@@ -1,30 +1,60 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { log, onLog } from "./event-bus";
 
-describe("event-bus", () => {
+const EXPECTED_CALL_COUNT = 1;
+const FIRST_CALL_INDEX = 0;
+const CONTEXT_ID = 1;
+
+const getFirstInvocationCallOrder = (spy: ReturnType<typeof vi.fn>): number =>
+  spy.mock.invocationCallOrder[FIRST_CALL_INDEX] ?? Number.NaN;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("log", () => {
   it("returns undefined and does not throw when no subscribers exist", () => {
     expect(() => log({ level: "info", message: "noop" })).not.toThrow();
     expect(log({ level: "info", message: "noop-2" })).toBeUndefined();
   });
+});
 
+describe("onLog delivery", () => {
   it("delivers the exact event to a single subscriber", () => {
     const handler = vi.fn();
     const cleanup = onLog(handler);
     const event = {
+      context: { id: CONTEXT_ID },
       level: "warn",
       message: "hello",
       source: "test",
-      context: { id: 1 },
     } as const;
 
     log(event);
 
-    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(EXPECTED_CALL_COUNT);
     expect(handler).toHaveBeenCalledWith(event);
     cleanup();
   });
 
+  it("ignores non-log events delivered by the browser listener", () => {
+    vi.spyOn(EventTarget.prototype, "addEventListener").mockImplementation(
+      (_type, listener): void => {
+        if (typeof listener === "function") {
+          listener(new Event("not-log"));
+        }
+      },
+    );
+    const handler = vi.fn();
+    const cleanup = onLog(handler);
+
+    expect(handler).not.toHaveBeenCalled();
+    cleanup();
+  });
+});
+
+describe("onLog cleanup", () => {
   it("stops delivery after unsubscribe", () => {
     const handler = vi.fn();
     const cleanup = onLog(handler);
@@ -33,25 +63,7 @@ describe("event-bus", () => {
     cleanup();
     log({ level: "info", message: "two" });
 
-    expect(handler).toHaveBeenCalledTimes(1);
-  });
-
-  it("delivers events in registration order", () => {
-    const first = vi.fn();
-    const second = vi.fn();
-    const cleanupFirst = onLog(first);
-    const cleanupSecond = onLog(second);
-
-    log({ level: "info", message: "x" });
-
-    expect(first).toHaveBeenCalledTimes(1);
-    expect(second).toHaveBeenCalledTimes(1);
-    expect(first.mock.invocationCallOrder[0]).toBeLessThan(
-      second.mock.invocationCallOrder[0],
-    );
-
-    cleanupFirst();
-    cleanupSecond();
+    expect(handler).toHaveBeenCalledTimes(EXPECTED_CALL_COUNT);
   });
 
   it("supports idempotent double-unsubscribe", () => {
@@ -63,5 +75,25 @@ describe("event-bus", () => {
     log({ level: "error", message: "ignored" });
 
     expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("onLog ordering", () => {
+  it("delivers events in registration order", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const cleanupFirst = onLog(first);
+    const cleanupSecond = onLog(second);
+
+    log({ level: "info", message: "x" });
+
+    expect(first).toHaveBeenCalledTimes(EXPECTED_CALL_COUNT);
+    expect(second).toHaveBeenCalledTimes(EXPECTED_CALL_COUNT);
+    expect(getFirstInvocationCallOrder(first)).toBeLessThan(
+      getFirstInvocationCallOrder(second),
+    );
+
+    cleanupFirst();
+    cleanupSecond();
   });
 });

--- a/packages/utils/module/event-bus/event-bus.ts
+++ b/packages/utils/module/event-bus/event-bus.ts
@@ -1,0 +1,31 @@
+import type { LogEvent } from "./log-event";
+
+import { isLogCustomEvent } from "./is-log-custom-event";
+
+const LOG_EVENT_NAME = "bruff:log";
+
+const eventTarget = new EventTarget();
+
+/**
+ * Emits a log event to all active subscribers.
+ */
+export const log = (event: LogEvent): void => {
+  eventTarget.dispatchEvent(new CustomEvent<LogEvent>(LOG_EVENT_NAME, { detail: event }));
+};
+
+/**
+ * Registers a log event subscriber and returns a cleanup callback.
+ */
+export const onLog = (handler: (event: LogEvent) => void): (() => void) => {
+  const listener = (event: Event): void => {
+    if (isLogCustomEvent(event)) {
+      handler(event.detail);
+    }
+  };
+
+  eventTarget.addEventListener(LOG_EVENT_NAME, listener);
+
+  return (): void => {
+    eventTarget.removeEventListener(LOG_EVENT_NAME, listener);
+  };
+};

--- a/packages/utils/module/event-bus/event-bus.ts
+++ b/packages/utils/module/event-bus/event-bus.ts
@@ -10,7 +10,9 @@ const eventTarget = new EventTarget();
  * Emits a log event to all active subscribers.
  */
 export const log = (event: LogEvent): void => {
-  eventTarget.dispatchEvent(new CustomEvent<LogEvent>(LOG_EVENT_NAME, { detail: event }));
+  eventTarget.dispatchEvent(
+    new CustomEvent<LogEvent>(LOG_EVENT_NAME, { detail: event }),
+  );
 };
 
 /**

--- a/packages/utils/module/event-bus/event-bus.ts
+++ b/packages/utils/module/event-bus/event-bus.ts
@@ -1,6 +1,5 @@
-import type { LogEvent } from "./log-event";
-
 import { isLogCustomEvent } from "./is-log-custom-event";
+import type { LogEvent } from "./log-event";
 
 const LOG_EVENT_NAME = "bruff:log";
 

--- a/packages/utils/module/event-bus/is-log-custom-event.test.ts
+++ b/packages/utils/module/event-bus/is-log-custom-event.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { isLogCustomEvent } from "./is-log-custom-event";
+
+describe("isLogCustomEvent", () => {
+  it("returns true for a valid log CustomEvent", () => {
+    const event = new CustomEvent("bruff:log", {
+      detail: { level: "info", message: "hello" },
+    });
+
+    expect(isLogCustomEvent(event)).toBe(true);
+  });
+
+  it("returns true regardless of event name when detail matches shape", () => {
+    const event = new CustomEvent("wrong:name", {
+      detail: { level: "warn", message: "hello" },
+    });
+
+    expect(isLogCustomEvent(event)).toBe(true);
+  });
+
+  it("returns false for non-CustomEvent values", () => {
+    const event = new Event("bruff:log");
+
+    expect(isLogCustomEvent(event)).toBe(false);
+  });
+
+  it("returns false for malformed detail", () => {
+    const invalidLevelEvent = new CustomEvent("bruff:log", {
+      detail: { level: "oops", message: "hello" },
+    });
+    const missingMessageEvent = new CustomEvent("bruff:log", {
+      detail: { level: "debug" },
+    });
+
+    expect(isLogCustomEvent(invalidLevelEvent)).toBe(false);
+    expect(isLogCustomEvent(missingMessageEvent)).toBe(false);
+  });
+});

--- a/packages/utils/module/event-bus/is-log-custom-event.ts
+++ b/packages/utils/module/event-bus/is-log-custom-event.ts
@@ -4,12 +4,17 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
 const isLogLevel = (level: unknown): level is LogEvent["level"] =>
-  level === "debug" || level === "info" || level === "warn" || level === "error";
+  level === "debug" ||
+  level === "info" ||
+  level === "warn" ||
+  level === "error";
 
 /**
  * Narrows unknown events into log CustomEvents.
  */
-export const isLogCustomEvent = (event: Event): event is CustomEvent<LogEvent> => {
+export const isLogCustomEvent = (
+  event: Event,
+): event is CustomEvent<LogEvent> => {
   if (!(event instanceof CustomEvent) || !isRecord(event.detail)) {
     return false;
   }

--- a/packages/utils/module/event-bus/is-log-custom-event.ts
+++ b/packages/utils/module/event-bus/is-log-custom-event.ts
@@ -1,0 +1,19 @@
+import type { LogEvent } from "./log-event";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isLogLevel = (level: unknown): level is LogEvent["level"] =>
+  level === "debug" || level === "info" || level === "warn" || level === "error";
+
+/**
+ * Narrows unknown events into log CustomEvents.
+ */
+export const isLogCustomEvent = (event: Event): event is CustomEvent<LogEvent> => {
+  if (!(event instanceof CustomEvent) || !isRecord(event.detail)) {
+    return false;
+  }
+
+  const { level, message } = event.detail;
+  return isLogLevel(level) && typeof message === "string";
+};

--- a/packages/utils/module/event-bus/log-event.ts
+++ b/packages/utils/module/event-bus/log-event.ts
@@ -1,0 +1,11 @@
+import type { LogLevel } from "./log-level";
+
+/**
+ * Payload emitted through the log event bus.
+ */
+export type LogEvent = Readonly<{
+  level: LogLevel;
+  message: string;
+  source?: string;
+  context?: Readonly<Record<string, unknown>>;
+}>;

--- a/packages/utils/module/event-bus/log-level.ts
+++ b/packages/utils/module/event-bus/log-level.ts
@@ -1,0 +1,4 @@
+/**
+ * Supported log event severity levels.
+ */
+export type LogLevel = "debug" | "info" | "warn" | "error";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,10 @@ importers:
         version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.10)
 
   packages/game-element:
+    dependencies:
+      '@bruff/utils':
+        specifier: workspace:0.0.0
+        version: link:../utils
     devDependencies:
       '@bruff/eslint-config':
         specifier: workspace:0.0.0

--- a/specs/event-bus-logging/acceptance.md
+++ b/specs/event-bus-logging/acceptance.md
@@ -101,3 +101,31 @@ The vitest coverage gate (`branches/functions/lines/statements = 100`) passes fo
 [`pnpm run lint`, `pnpm run typecheck`]
 
 No `as` casts, no `any`, no module-level `let`, no exported mutable bindings introduced.
+
+## A14 — Canvas resize logs emit through the log bus
+
+[`packages/utils/module/canvas/canvas-resize-listener.test.ts`]
+
+Given `canvasResizeListener(canvas)` is active,
+When `"elementResized"` is dispatched,
+Then an `info` log event with message `"elementResized"` is observed through `onLog`.
+
+## A15 — Game entry registration emits through the log bus
+
+[`packages/game/lib/effects/entry.test.ts`]
+
+Given `<bruff-game>` is not yet registered,
+When the entry module is imported,
+Then it defines the custom element, starts the loop, and emits an `info` log event through `log()`.
+
+## A16 — Game loop emits setup and touch logs through the log bus
+
+[`packages/game/lib/effects/loop.test.ts`]
+
+Given setup fails,
+When `loop()` runs,
+Then an `error` log event with the setup failure reason is emitted through `log()`.
+
+Given setup succeeds and the touch observable emits an action,
+When the touch action is observed,
+Then an `info` log event with the touch action type is emitted through `log()`.

--- a/specs/event-bus-logging/design.md
+++ b/specs/event-bus-logging/design.md
@@ -161,6 +161,17 @@ The `!this.#unsubscribe` guard preserves GE-3 (`connectedCallback` idempotent) f
 
 `#unsubscribe` is a `private` (ECMAScript private) field — not exported, not module-level, instance-scoped. That keeps C-19 satisfied (module-level state is forbidden; instance state in the imperative shell is fine — the project's only declared instance state today, but allowed by GE-1).
 
+## Contributor Guidance Updates
+
+| File                                        | Required guidance                                                                                        |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `AGENTS.md`                                 | Production logging uses the event bus; direct `console.*` is limited to the console sink and tests.      |
+| `packages/game/AGENTS.override.md`          | `log()` is allowed only from `effects/` or the entry point; pure layers remain no-log.                   |
+| `packages/utils/AGENTS.override.md`         | `@bruff/utils` includes pure helpers plus shell-adjacent browser/logging services.                       |
+| `packages/game-element/AGENTS.override.md`  | `GameElement` owns the `onLog(consoleLogHandler)` subscription lifecycle while connected.                |
+| `.agents/skills/verify-layers/SKILL.md`     | Layer audits check that pure layers do not import `log()` and production code avoids direct `console.*`. |
+| `.agents/skills/roguelike-feature/SKILL.md` | New shell diagnostics use `log()` from `@bruff/utils`, not direct `console.*` calls.                     |
+
 ## Tradeoffs and alternatives considered
 
 ### Where the bus lives

--- a/specs/event-bus-logging/design.md
+++ b/specs/event-bus-logging/design.md
@@ -2,13 +2,16 @@
 
 ## Layer assignment
 
-| Module                                                       | Package              | Layer                                                                                                                                  |
-| ------------------------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `module/event-bus/log-level.ts`                              | `@bruff/utils`       | Pure data — exports the `LogLevel` discriminated string union.                                                                         |
-| `module/event-bus/log-event.ts`                              | `@bruff/utils`       | Pure data — exports the `LogEvent` `Readonly` record type.                                                                             |
-| `module/event-bus/event-bus.ts`                              | `@bruff/utils`       | Shell-ish service — owns the private `EventTarget` instance and exposes `log()` / `onLog()`. Same tier as `canvas-resize-listener.ts`. |
-| `module/event-bus/console-log-handler.ts`                    | `@bruff/utils`       | Pure mapper — `(event) => void` that picks the right `console` method. Console is a side effect, but the function has no other state. |
-| Extension to `module/game-element.ts`                        | `@bruff/game-element`| Imperative shell — wires `onLog(consoleLogHandler)` into `connectedCallback` / `disconnectedCallback`.                                 |
+| Module                                                  | Package               | Layer                                                                                                                                  |
+| ------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `module/event-bus/log-level.ts`                         | `@bruff/utils`        | Pure data — exports the `LogLevel` discriminated string union.                                                                         |
+| `module/event-bus/log-event.ts`                         | `@bruff/utils`        | Pure data — exports the `LogEvent` `Readonly` record type.                                                                             |
+| `module/event-bus/event-bus.ts`                         | `@bruff/utils`        | Shell-ish service — owns the private `EventTarget` instance and exposes `log()` / `onLog()`. Same tier as `canvas-resize-listener.ts`. |
+| `module/event-bus/console-log-handler.ts`               | `@bruff/utils`        | Pure mapper — `(event) => void` that picks the right `console` method. Console is a side effect, but the function has no other state.  |
+| Extension to `module/game-element.ts`                   | `@bruff/game-element` | Imperative shell — wires `onLog(consoleLogHandler)` into `connectedCallback` / `disconnectedCallback`.                                 |
+| `lib/effects/entry.ts` log migration                    | `@bruff/game`         | Effects entry — emits custom element registration logs through `log()` instead of `console.info`.                                      |
+| `lib/effects/loop.ts` log migration                     | `@bruff/game`         | Effects loop — emits setup failure and touch input logs through `log()` instead of `console.*`.                                        |
+| `module/canvas/canvas-resize-listener.ts` log migration | `@bruff/utils`        | Shell-adjacent canvas utility — emits resize logs through `log()` instead of `console.info`.                                           |
 
 The bus singleton is the only piece of "module-level service state" introduced. C-19 forbids _exported_ module-level mutable bindings; the `EventTarget` instance here is **not exported** — only the `log` / `onLog` functions are. The instance is encapsulated, frozen behind the module boundary, and identical in spirit to a closure-over-private-state factory invoked once at module load.
 
@@ -62,6 +65,15 @@ log({...})  ─────────► dispatchEvent(CustomEvent)
 
 `emit` / `on` are intentionally _not_ exported. The transport is `EventTarget` today and may become `BroadcastChannel` or `Worker.postMessage` later — keeping the surface narrow protects callers from that swap.
 
+Existing effect and shell-adjacent call sites emit structured log events:
+
+| File                                                     | Event                                                                                                  |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `packages/game/lib/effects/entry.ts`                     | `{ level: "info", message: "bruff game v<version> was defined", source: "@bruff/game/effects/entry" }` |
+| `packages/game/lib/effects/loop.ts` setup failure        | `{ level: "error", message: "setup failed", source: "@bruff/game/effects/loop", context: { error } }`  |
+| `packages/game/lib/effects/loop.ts` touch input          | `{ level: "info", message: "touch", source: "@bruff/game/effects/loop", context: { actionType } }`     |
+| `packages/utils/module/canvas/canvas-resize-listener.ts` | `{ level: "info", message: "elementResized", source: "@bruff/utils/canvas" }`                          |
+
 ## Internal implementation sketch
 
 ```ts
@@ -75,7 +87,9 @@ const createLogBus = (): {
   const bus = new EventTarget();
 
   const dispatch = (event: LogEvent): void => {
-    bus.dispatchEvent(new CustomEvent<LogEvent>(LOG_EVENT_NAME, { detail: event }));
+    bus.dispatchEvent(
+      new CustomEvent<LogEvent>(LOG_EVENT_NAME, { detail: event }),
+    );
   };
 
   const subscribe = (handler: (event: LogEvent) => void): (() => void) => {
@@ -103,7 +117,10 @@ Note on the narrowing: `CustomEvent.detail` is typed as the generic parameter of
 export const consoleLogHandler = (event: LogEvent): void => {
   const sink = pickConsoleSink(event.level);
   if (event.context !== undefined || event.source !== undefined) {
-    sink(formatPrefix(event), event.message, { source: event.source, context: event.context });
+    sink(formatPrefix(event), event.message, {
+      source: event.source,
+      context: event.context,
+    });
   } else {
     sink(formatPrefix(event), event.message);
   }
@@ -134,7 +151,9 @@ export class GameElement extends HTMLElement {
     }
   }
 
-  static template(): string { /* unchanged */ }
+  static template(): string {
+    /* unchanged */
+  }
 }
 ```
 
@@ -169,7 +188,9 @@ The `!this.#unsubscribe` guard preserves GE-3 (`connectedCallback` idempotent) f
 
 ## Reuse map
 
-- `packages/utils/module/canvas/canvas-resize-listener.ts` — precedent for shell-ish helpers living in `@bruff/utils`; precedent for `console.*` calls in this layer.
+- `packages/game/lib/effects/entry.ts` — existing custom-element registration log migrated to `log()`.
+- `packages/game/lib/effects/loop.ts` — existing setup failure and touch input logs migrated to `log()`.
+- `packages/utils/module/canvas/canvas-resize-listener.ts` — existing canvas resize log migrated to `log()`.
 - `packages/utils/module/canvas/create-canvas-resize-observer.ts` — precedent for constructing `CustomEvent` and wiring through `EventTarget`-shaped APIs.
 - `packages/utils/module/get-shadow-game-root.ts` — example of TSDoc + arrow-function style to mirror.
 - `packages/game-element/module/game-element.ts` — file we extend; current `connectedCallback` shape and idempotency guard are the model for the new branch.

--- a/specs/event-bus-logging/spec.md
+++ b/specs/event-bus-logging/spec.md
@@ -48,3 +48,20 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - An `onLog` cleanup function called twice — idempotent (second call is a no-op).
 - A subscriber that calls its own cleanup mid-dispatch — safe under `EventTarget` semantics.
 - `console.debug` is silenced by default in many browsers; emitting `level: "debug"` events is therefore intentionally a near-no-op visually. This is documented but not "fixed".
+
+
+## Verification
+
+- `log()` no-op with no subscribers → `packages/utils/module/event-bus/event-bus.test.ts` (`returns undefined and does not throw when no subscribers exist`).
+- `level` constrained to debug/info/warn/error → `packages/utils/module/event-bus/log-level.ts`; exercised by `packages/utils/module/event-bus/console-log-handler.test.ts` table-driven level routing test.
+- `onLog(handler)` returns cleanup unsubscribe function → `packages/utils/module/event-bus/event-bus.ts`; validated by unsubscribe and double-unsubscribe tests in `packages/utils/module/event-bus/event-bus.test.ts`.
+- Connected `GameElement` forwards to console by level → `packages/game-element/module/game-element.test.ts` (forwards log events while connected).
+- Removed `GameElement` stops forwarding → `packages/game-element/module/game-element.test.ts` (stops forwarding after disconnect).
+- Console call includes level/message and optional source/context → `packages/utils/module/event-bus/console-log-handler.test.ts` (without metadata + with metadata cases).
+- Multiple subscribers receive same event in registration order → `packages/utils/module/event-bus/event-bus.test.ts` (registration order assertion).
+- Pre-subscription `log()` calls are unobserved and non-throwing → `packages/utils/module/event-bus/event-bus.test.ts` (no subscribers case).
+- Edge case: empty message still dispatched → covered by generic dispatch path in `packages/utils/module/event-bus/event-bus.ts` and single-subscriber test payload equality semantics.
+- Edge case: re-entrant logging supported by EventTarget semantics → not explicitly unit-tested; left to platform behavior noted in design.
+- Edge case: disconnected without prior connect no-op → `packages/game-element/module/game-element.test.ts` (disconnectedCallback no-op).
+- Edge case: connect/disconnect cycles cleanly resubscribe → `packages/game-element/module/game-element.test.ts` (resubscribes after reconnect).
+- Edge case: cleanup called twice idempotent → `packages/utils/module/event-bus/event-bus.test.ts` (double-unsubscribe).

--- a/specs/event-bus-logging/spec.md
+++ b/specs/event-bus-logging/spec.md
@@ -21,7 +21,6 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - Forwarding logs to remote sinks (Faro, Sentry, custom HTTP endpoints). The bus is the seam that makes those additions trivial later, but they are not in this feature.
 - Worker-thread bridging via `postMessage`. The design must not preclude it, but no worker code ships in this feature.
 - A generic, multi-channel typed event bus. Only the `"log"` channel is defined here. The bus implementation is generic enough that other channels can be added later without rework, but no other channels exist yet.
-- Replacing existing direct `console.*` calls in the codebase (e.g. `canvas-resize-listener.ts`'s `console.info`). Migrations happen in follow-up work, not this feature.
 - A `Result<T, E>` / `Option<T>` rollout. Those types are aspirational in `CLAUDE.md` but not yet adopted in `@bruff/utils`. Introducing them here would balloon scope; this feature stays consistent with current code (functions return `void` or values, no throws on the bus path).
 - Branded types for `LogLevel` etc. The discriminated string union is sufficient and matches existing util style.
 
@@ -33,8 +32,10 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
   A: Scoped. We expose `log()` and `onLog()` only. The internal `EventTarget` instance stays private to the module so future channels can be added without leaking the transport. No `emit(name, payload)` public API in this feature.
 - **Q: How does the `GameElement` avoid duplicate console output if multiple instances mount?**
   A: Each instance subscribes on `connectedCallback` and unsubscribes on `disconnectedCallback`. If two `GameElement`s are mounted simultaneously, each event prints twice — accepted as a known, low-risk behaviour because the app has one `GameElement` in practice. A module-level "subscribe once" guard would require module-level mutable state (violates C-19) for negligible benefit.
-- **Q: Should `log()` be allowed to be called from pure-core game code in `@bruff/game`?**
-  A: Yes, treated as the same allowance the codebase already grants `console.info` (see `canvas-resize-listener.ts`). Logging is the canonical "small, observable side effect" exception. Stricter purity (a `Writer` monad) is out of scope.
+- **Q: Should `log()` be allowed in effects and shell-adjacent utility code?**
+  A: Yes. Effects and shell-adjacent utilities may emit typed log events instead of calling `console.*` directly. Pure core/state/input/render code should still avoid logging side effects.
+- **Q: Should the initial migration include existing direct `console.*` call sites?**
+  A: Yes. `packages/game/lib/effects/entry.ts`, `packages/game/lib/effects/loop.ts`, and `packages/utils/module/canvas/canvas-resize-listener.ts` are part of this feature so all existing app logs flow through the bus before `GameElement` forwards them to the console.
 - **Q: What happens if a subscriber throws?**
   A: `EventTarget`'s `dispatchEvent` swallows listener exceptions and reports them via `window.onerror`. This is acceptable browser-native behaviour; we do not wrap or re-throw.
 
@@ -48,7 +49,7 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - An `onLog` cleanup function called twice — idempotent (second call is a no-op).
 - A subscriber that calls its own cleanup mid-dispatch — safe under `EventTarget` semantics.
 - `console.debug` is silenced by default in many browsers; emitting `level: "debug"` events is therefore intentionally a near-no-op visually. This is documented but not "fixed".
-
+- Existing setup failure, custom element registration, touch input, and canvas resize logs keep their observable intent while switching from direct `console.*` calls to `log()`.
 
 ## Verification
 
@@ -65,3 +66,5 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - Edge case: disconnected without prior connect no-op → `packages/game-element/module/game-element.test.ts` (disconnectedCallback no-op).
 - Edge case: connect/disconnect cycles cleanly resubscribe → `packages/game-element/module/game-element.test.ts` (resubscribes after reconnect).
 - Edge case: cleanup called twice idempotent → `packages/utils/module/event-bus/event-bus.test.ts` (double-unsubscribe).
+- Existing direct console call migrations → `packages/game/lib/effects/entry.test.ts`, `packages/game/lib/effects/loop.test.ts`, and `packages/utils/module/canvas/canvas-resize-listener.test.ts`.
+- Affected package gates run on 2026-05-12 → `@bruff/utils` format/lint/test/typecheck passed; `@bruff/game` format/lint/test/typecheck/build passed; `@bruff/game-element` format/lint/test/typecheck passed. `@bruff/utils` and `@bruff/game-element` have no package-level build script.

--- a/specs/event-bus-logging/spec.md
+++ b/specs/event-bus-logging/spec.md
@@ -14,6 +14,7 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - The console line includes the level, message, and (when supplied) the `source` and `context` fields, so a developer can tell where the log came from at a glance.
 - Multiple subscribers receive the same event; subscriber order matches registration order.
 - `log()` calls before any subscriber is attached do not error and are simply unobserved (matches native `EventTarget` semantics — there is no replay buffer).
+- Repository guidance documents the event-bus boundary: production logging emits through `log()`, `console.*` is isolated to the console sink, and pure layers/skills remain no-log.
 
 ## Out of scope
 
@@ -36,6 +37,8 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
   A: Yes. Effects and shell-adjacent utilities may emit typed log events instead of calling `console.*` directly. Pure core/state/input/render code should still avoid logging side effects.
 - **Q: Should the initial migration include existing direct `console.*` call sites?**
   A: Yes. `packages/game/lib/effects/entry.ts`, `packages/game/lib/effects/loop.ts`, and `packages/utils/module/canvas/canvas-resize-listener.ts` are part of this feature so all existing app logs flow through the bus before `GameElement` forwards them to the console.
+- **Q: Should AGENTS and local skill guidance mention the new event-bus boundary?**
+  A: Yes. Root/package AGENTS files should state that production logging uses `log()` and that `console.*` is isolated to `consoleLogHandler`. Local skills that guide shell wiring or layer audits should reflect the same boundary while preserving no-logging rules for pure domain work.
 - **Q: What happens if a subscriber throws?**
   A: `EventTarget`'s `dispatchEvent` swallows listener exceptions and reports them via `window.onerror`. This is acceptable browser-native behaviour; we do not wrap or re-throw.
 
@@ -50,6 +53,7 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - A subscriber that calls its own cleanup mid-dispatch — safe under `EventTarget` semantics.
 - `console.debug` is silenced by default in many browsers; emitting `level: "debug"` events is therefore intentionally a near-no-op visually. This is documented but not "fixed".
 - Existing setup failure, custom element registration, touch input, and canvas resize logs keep their observable intent while switching from direct `console.*` calls to `log()`.
+- Documentation for future contributors must not imply that `@bruff/utils` is pure-only or that `GameElement` only mounts a canvas; both now include narrow shell-adjacent logging responsibilities.
 
 ## Verification
 
@@ -68,3 +72,4 @@ Provide a zero-dependency, in-process event bus that any code in the workspace c
 - Edge case: cleanup called twice idempotent → `packages/utils/module/event-bus/event-bus.test.ts` (double-unsubscribe).
 - Existing direct console call migrations → `packages/game/lib/effects/entry.test.ts`, `packages/game/lib/effects/loop.test.ts`, and `packages/utils/module/canvas/canvas-resize-listener.test.ts`.
 - Affected package gates run on 2026-05-12 → `@bruff/utils` format/lint/test/typecheck passed; `@bruff/game` format/lint/test/typecheck/build passed; `@bruff/game-element` format/lint/test/typecheck passed. `@bruff/utils` and `@bruff/game-element` have no package-level build script.
+- Contributor guidance audit → `AGENTS.md`, `packages/game/AGENTS.override.md`, `packages/utils/AGENTS.override.md`, `packages/game-element/AGENTS.override.md`, `.agents/skills/verify-layers/SKILL.md`, and `.agents/skills/roguelike-feature/SKILL.md` updated to describe the event-bus logging boundary.

--- a/specs/event-bus-logging/tasks.md
+++ b/specs/event-bus-logging/tasks.md
@@ -1,19 +1,19 @@
 # Event Bus Logging — Tasks
 
-- [ ] T1 — Add `LogLevel` type in `packages/utils/module/event-bus/log-level.ts`.
-- [ ] T2 — Add `LogEvent` type in `packages/utils/module/event-bus/log-event.ts`.
-- [ ] T3 — Add `isLogCustomEvent` type guard in `packages/utils/module/event-bus/is-log-custom-event.ts`.
-- [ ] T4 — Add unit tests for `isLogCustomEvent` covering match, wrong-name, non-CustomEvent, and malformed-detail cases in `packages/utils/module/event-bus/is-log-custom-event.test.ts`.
-- [ ] T5 — Implement `log` and `onLog` (with private singleton `EventTarget`) in `packages/utils/module/event-bus/event-bus.ts`.
-- [ ] T6 — Add unit tests for `event-bus`: emit-with-no-listeners, single subscriber receives event, unsubscribe stops delivery, multiple subscribers receive in registration order, double-unsubscribe is idempotent — in `packages/utils/module/event-bus/event-bus.test.ts`.
-- [ ] T7 — Implement `consoleLogHandler` in `packages/utils/module/event-bus/console-log-handler.ts` (switch on `LogLevel` → `console.{debug,info,warn,error}`; include `source` / `context` only when present).
-- [ ] T8 — Add unit tests for `consoleLogHandler` covering each `LogLevel`, with-and-without `source`, with-and-without `context` in `packages/utils/module/event-bus/console-log-handler.test.ts`.
-- [ ] T9 — Re-export `log`, `onLog`, `consoleLogHandler`, and the `LogLevel` / `LogEvent` types from `packages/utils/index.ts`.
-- [ ] T10 — Update `packages/utils/README.md` with an "Event bus" section documenting `log`, `onLog`, `consoleLogHandler`, `LogLevel`, `LogEvent`.
-- [ ] T11 — Add `@bruff/utils` workspace dependency to `packages/game-element/package.json`.
-- [ ] T12 — Add `#unsubscribe` field plus `onLog(consoleLogHandler)` subscription in `connectedCallback` in `packages/game-element/module/game-element.ts`, preserving the existing shadow-root idempotency guard.
-- [ ] T13 — Add `disconnectedCallback` to `GameElement` that calls and clears `#unsubscribe`.
-- [ ] T14 — Add unit tests in `packages/game-element/module/game-element.test.ts` covering: connect → log() → console method invoked at correct level; disconnect → log() → no longer reaches that instance; reconnect after disconnect re-subscribes; `disconnectedCallback` called without prior connect is a no-op.
-- [ ] T15 — Update `packages/game-element/README.md` with a "Console log forwarding" section noting that `GameElement` subscribes to `@bruff/utils`'s log bus while connected.
-- [ ] T16 — Run `pnpm run ok` (or per-package `format` / `lint` / `test` / `typecheck` / `build`) for `@bruff/utils` and `@bruff/game-element`; confirm 100% coverage thresholds still pass.
-- [ ] T17 — Review phase: walk `spec.md`'s "User-visible behaviour" / "Edge cases" lists and append a `## Verification` section to `spec.md` mapping each bullet to the test that proves it.
+- [x] T1 — Add `LogLevel` type in `packages/utils/module/event-bus/log-level.ts`.
+- [x] T2 — Add `LogEvent` type in `packages/utils/module/event-bus/log-event.ts`.
+- [x] T3 — Add `isLogCustomEvent` type guard in `packages/utils/module/event-bus/is-log-custom-event.ts`.
+- [x] T4 — Add unit tests for `isLogCustomEvent` covering match, wrong-name, non-CustomEvent, and malformed-detail cases in `packages/utils/module/event-bus/is-log-custom-event.test.ts`.
+- [x] T5 — Implement `log` and `onLog` (with private singleton `EventTarget`) in `packages/utils/module/event-bus/event-bus.ts`.
+- [x] T6 — Add unit tests for `event-bus`: emit-with-no-listeners, single subscriber receives event, unsubscribe stops delivery, multiple subscribers receive in registration order, double-unsubscribe is idempotent — in `packages/utils/module/event-bus/event-bus.test.ts`.
+- [x] T7 — Implement `consoleLogHandler` in `packages/utils/module/event-bus/console-log-handler.ts` (switch on `LogLevel` → `console.{debug,info,warn,error}`; include `source` / `context` only when present).
+- [x] T8 — Add unit tests for `consoleLogHandler` covering each `LogLevel`, with-and-without `source`, with-and-without `context` in `packages/utils/module/event-bus/console-log-handler.test.ts`.
+- [x] T9 — Re-export `log`, `onLog`, `consoleLogHandler`, and the `LogLevel` / `LogEvent` types from `packages/utils/index.ts`.
+- [x] T10 — Update `packages/utils/README.md` with an "Event bus" section documenting `log`, `onLog`, `consoleLogHandler`, `LogLevel`, `LogEvent`.
+- [x] T11 — Add `@bruff/utils` workspace dependency to `packages/game-element/package.json`.
+- [x] T12 — Add `#unsubscribe` field plus `onLog(consoleLogHandler)` subscription in `connectedCallback` in `packages/game-element/module/game-element.ts`, preserving the existing shadow-root idempotency guard.
+- [x] T13 — Add `disconnectedCallback` to `GameElement` that calls and clears `#unsubscribe`.
+- [x] T14 — Add unit tests in `packages/game-element/module/game-element.test.ts` covering: connect → log() → console method invoked at correct level; disconnect → log() → no longer reaches that instance; reconnect after disconnect re-subscribes; `disconnectedCallback` called without prior connect is a no-op.
+- [x] T15 — Update `packages/game-element/README.md` with a "Console log forwarding" section noting that `GameElement` subscribes to `@bruff/utils`'s log bus while connected.
+- [x] T16 — Run `pnpm run ok` (or per-package `format` / `lint` / `test` / `typecheck` / `build`) for `@bruff/utils` and `@bruff/game-element`; confirm 100% coverage thresholds still pass.
+- [x] T17 — Review phase: walk `spec.md`'s "User-visible behaviour" / "Edge cases" lists and append a `## Verification` section to `spec.md` mapping each bullet to the test that proves it.

--- a/specs/event-bus-logging/tasks.md
+++ b/specs/event-bus-logging/tasks.md
@@ -17,3 +17,9 @@
 - [x] T15 — Update `packages/game-element/README.md` with a "Console log forwarding" section noting that `GameElement` subscribes to `@bruff/utils`'s log bus while connected.
 - [x] T16 — Run `pnpm run ok` (or per-package `format` / `lint` / `test` / `typecheck` / `build`) for `@bruff/utils` and `@bruff/game-element`; confirm 100% coverage thresholds still pass.
 - [x] T17 — Review phase: walk `spec.md`'s "User-visible behaviour" / "Edge cases" lists and append a `## Verification` section to `spec.md` mapping each bullet to the test that proves it.
+- [x] T18 — Update `specs/event-bus-logging/spec.md`, `specs/event-bus-logging/design.md`, `specs/event-bus-logging/tasks.md`, and `specs/event-bus-logging/acceptance.md` to include the `GameElement` subscription requirement and the direct-console migration scope for `packages/game/lib/effects/entry.ts`, `packages/game/lib/effects/loop.ts`, and `packages/utils/module/canvas/canvas-resize-listener.ts`.
+- [x] T19 — Add tests proving `packages/utils/module/canvas/canvas-resize-listener.ts` emits resize events through `log()` instead of calling `console.info`.
+- [x] T20 — Add tests proving `packages/game/lib/effects/entry.ts` and `packages/game/lib/effects/loop.ts` emit registration, setup failure, and touch input messages through `log()`.
+- [x] T21 — Replace direct `console.*` calls with `log()` in `packages/game/lib/effects/entry.ts`, `packages/game/lib/effects/loop.ts`, and `packages/utils/module/canvas/canvas-resize-listener.ts`.
+- [x] T22 — Run the affected `@bruff/utils`, `@bruff/game`, and `@bruff/game-element` format, lint, test, typecheck, and build gates.
+- [x] T23 — Review phase: update `specs/event-bus-logging/spec.md` verification notes after the console migration tests pass.

--- a/specs/event-bus-logging/tasks.md
+++ b/specs/event-bus-logging/tasks.md
@@ -23,3 +23,7 @@
 - [x] T21 — Replace direct `console.*` calls with `log()` in `packages/game/lib/effects/entry.ts`, `packages/game/lib/effects/loop.ts`, and `packages/utils/module/canvas/canvas-resize-listener.ts`.
 - [x] T22 — Run the affected `@bruff/utils`, `@bruff/game`, and `@bruff/game-element` format, lint, test, typecheck, and build gates.
 - [x] T23 — Review phase: update `specs/event-bus-logging/spec.md` verification notes after the console migration tests pass.
+- [x] T24 — Audit `AGENTS.md`, `packages/*/AGENTS.override.md`, and `.agents/skills/*/SKILL.md` for stale logging, console, shell, and layer guidance.
+- [x] T25 — Update `AGENTS.md`, `packages/game/AGENTS.override.md`, `packages/utils/AGENTS.override.md`, and `packages/game-element/AGENTS.override.md` with the event-bus logging boundary.
+- [x] T26 — Update `.agents/skills/verify-layers/SKILL.md` and `.agents/skills/roguelike-feature/SKILL.md` so future game work routes shell diagnostics through `log()`.
+- [x] T27 — Review phase: update `specs/event-bus-logging/spec.md` and `specs/event-bus-logging/design.md` to record the contributor-guidance audit.


### PR DESCRIPTION
### Motivation

- Provide a small, in-process logging event bus in `@bruff/utils` to emit and consume structured log events across the workspace. 
- Expose a `consoleLogHandler` so consumers can route bus events to the browser console with level, optional source, and context. 
- Make `GameElement` automatically forward log events to the console while connected and stop forwarding when disconnected.

### Description

- Add a scoped event-bus under `packages/utils/module/event-bus/` including `log`, `onLog`, `LogEvent`/`LogLevel` types, `isLogCustomEvent` guard, and an internal `EventTarget` implementation. 
- Implement `consoleLogHandler` to route `LogLevel` to `console.debug|info|warn|error` and include `source`/`context` when present, and add unit tests for it. 
- Re-export `log`, `onLog`, `consoleLogHandler`, and the types from `packages/utils/index.ts` and document the event bus in `packages/utils/README.md`. 
- Wire `GameElement` to subscribe with `onLog(consoleLogHandler)` on `connectedCallback` and unsubscribe on `disconnectedCallback`, add a private `#unsubscribe` field, update `packages/game-element/package.json` to depend on `@bruff/utils`, and document forwarding in `packages/game-element/README.md`. 
- Add comprehensive unit tests for the event bus and update `packages/game-element/module/game-element.test.ts` to cover forwarding, disconnect, reconnect, and the disconnected-before-connect no-op behavior.

### Testing

- Added and ran new Vitest unit tests for `packages/utils/module/event-bus` including `event-bus.test.ts`, `is-log-custom-event.test.ts`, and `console-log-handler.test.ts`, which verify dispatch, subscription ordering, unsubscribe idempotency, and console routing; tests passed. 
- Updated and ran `packages/game-element/module/game-element.test.ts` tests covering subscription behavior, reconnection, and the disconnected no-op; tests passed. 
- Per-package browser tests and coverage checks were exercised as part of development and 100% coverage expectations for the game-element package remain satisfied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0376e12970832a8e638fd674a270f1)