### PR TITLE
feat: add ANSI tty renderer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ The repo is a pnpm monorepo. Package-specific rules auto-load from `packages/<pa
 | `@bruff/arcade`        | E2E host — Vite app + Playwright tests across desktop/mobile browsers                | `packages/arcade/AGENTS.override.md`       |
 | `@bruff/sigil`         | Development-only font glyph JSON extraction tool                                     | `packages/sigil/AGENTS.override.md`        |
 | `@bruff/utils`         | Shared utilities — universal root helpers plus explicit DOM subpath services         | `packages/utils/AGENTS.override.md`        |
+| `@bruff/cli`           | Terminal shell spike — ANSI mock renderer with injected stdin/stdout boundaries      | `packages/cli/AGENTS.override.md`          |
 | `@bruff/eslint-config` | Shared ESLint flat config                                                            | (none — config-only package)               |
 
 When working in a single package, also read its `README.md` for build/test commands and architectural role.

--- a/packages/cli/AGENTS.override.md
+++ b/packages/cli/AGENTS.override.md
@@ -1,0 +1,38 @@
+# `@bruff/cli` — Terminal Shell Spike
+
+This package owns the mock-only ANSI terminal renderer. It proves terminal
+rendering mechanics without depending on game state, game render commands, or
+browser packages.
+
+- **Language**: TypeScript with TSDoc annotations.
+- **Role**: Node terminal shell plus small pure ANSI/render projection helpers.
+- **Runtime boundary**: Runtime and test source may import Node built-ins and
+  `@bruff/glyph`. Do not import `@bruff/game`, `@bruff/game-element`,
+  `@bruff/arcade`, `@bruff/sigil`, `@bruff/utils`, or workspace internals.
+
+## Package-Specific Allowances
+
+- **CL-1** ANSI terminal control is allowed only in `module/ansi.ts` as explicit
+  `AnsiCommand` encoding.
+- **CL-2** `process.stdin`, `process.stdout`, raw mode, and input listeners are
+  allowed only in `bin/bruff-cli.ts`, behind injected `TextInput` and
+  `TextWriter` ports.
+- **CL-3** `@bruff/glyph` may be used only as a character catalog for mock
+  terminal cells.
+
+## Package-Specific Obligations
+
+- **CL-4 (MUST)** The CLI remains mock-only until a future spec introduces an
+  explicit public game API for headless terminal rendering.
+- **CL-5 (MUST)** The CLI waits for only the minimal quit shortcuts: `q`, `Q`,
+  and `Ctrl+C`. Do not add gameplay input, resize handling, alternate screen
+  mode, mouse reporting, or a game loop in this package without a new spec.
+- **CL-6 (MUST)** If raw mode is enabled while waiting for a quit shortcut, it
+  must be disabled before input is paused.
+- **CL-7 (MUST)** Writer failures remain typed `WriteFrameResult` values.
+  Rendering or input setup must not throw for expected terminal failures.
+- **CL-8 (MUST)** Tests use native Node TypeScript execution with `node:test`
+  and `node:assert/strict`. Do not add Vitest, Jest, Playwright, browser APIs,
+  DOM APIs, `tsx`, `ts-node`, Babel, or Vite to this package.
+- **CL-9 (MUST)** Tests assert through public exports or injected CLI ports.
+  They must not open a real TTY or depend on a pseudo-terminal.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,38 @@
+# @bruff/cli
+
+Terminal ANSI renderer spike for deterministic Bruff mock scenes.
+
+## Scope
+
+`@bruff/cli` renders fixed mock terminal cells to ANSI text. It proves screen
+clearing, cursor movement, truecolor foregrounds, truecolor backgrounds, glyph
+output, prompt cleanup, and style reset behaviour without importing game state
+or render commands.
+
+Runtime and test source may import Node built-ins and `@bruff/glyph`. The package
+does not import `@bruff/game`, `@bruff/game-element`, `@bruff/arcade`, or
+`@bruff/utils`.
+
+## Commands
+
+```sh
+pnpm --filter @bruff/cli run cli
+pnpm --filter @bruff/cli run test
+pnpm --filter @bruff/cli run typecheck
+pnpm --filter @bruff/cli run lint
+pnpm --filter @bruff/cli run format
+```
+
+The `cli` command runs `.ts` files directly through native Node.js TypeScript
+support. Tests use `node:test` and `node:assert/strict`; no browser, DOM,
+runtime transpiler, bundler, Vitest, Jest, or Playwright runtime is used.
+
+When run in an interactive terminal, the command draws the mock scene and waits
+until the user presses `q`, `Q`, or `Ctrl+C`. The implementation uses injected
+input/output ports in tests, so tests do not need a real TTY.
+
+## Deferred Integration
+
+This package is mock-only. A later spec can connect terminal rendering to
+game-owned data through an explicit public game API. This package must not deep
+import game internals or introduce shared renderer types for game packages.

--- a/packages/cli/bin/bruff-cli.test.ts
+++ b/packages/cli/bin/bruff-cli.test.ts
@@ -1,10 +1,15 @@
 import * as assert from "node:assert/strict";
 
 import {
+  createTextInput,
+  isCliEntryPoint,
+  type ProcessTextInput,
   runBruffCli,
+  runBruffCliWithProcess,
   type TextInput,
   type TextInputChunk,
 } from "./bruff-cli.ts";
+import { pathToFileURL } from "node:url";
 import { test } from "node:test";
 import type { TextWriter } from "../module/write-frame.ts";
 
@@ -24,11 +29,17 @@ type FakeInput = TextInput &
     rawModes: () => ReadonlyArray<boolean>;
   }>;
 
+type FakeProcessInput = ProcessTextInput &
+  Readonly<{
+    eventLog: () => ReadonlyArray<string>;
+    rawModes: () => ReadonlyArray<boolean>;
+  }>;
+
 const ignoreInput = (chunk: TextInputChunk): void => {
   chunk.toString();
 };
 
-const createFakeInput = (isTTY: boolean): FakeInput => {
+const createFakeInput = (isTTY: boolean, supportsRawMode = true): FakeInput => {
   const rawModeLog: Array<boolean> = [];
   let dataListener: (chunk: TextInputChunk) => void = ignoreInput;
   let paused = true;
@@ -66,14 +77,135 @@ const createFakeInput = (isTTY: boolean): FakeInput => {
       paused = false;
       return input;
     },
-    setRawMode: (enabled: boolean): TextInput => {
-      rawModeLog.push(enabled);
-      return input;
-    },
+    setRawMode: supportsRawMode
+      ? (enabled: boolean): TextInput => {
+          rawModeLog.push(enabled);
+          return input;
+        }
+      : undefined,
   };
 
   return input;
 };
+
+const createFakeProcessInput = (
+  isTTY: boolean | undefined,
+  supportsRawMode = true,
+): FakeProcessInput => {
+  const eventLog: Array<string> = [];
+  const rawModeLog: Array<boolean> = [];
+
+  const processInput: FakeProcessInput = {
+    eventLog: (): ReadonlyArray<string> => eventLog,
+    isTTY,
+    off: (eventName: "data"): unknown => {
+      eventLog.push(`off:${eventName}`);
+      return undefined;
+    },
+    on: (eventName: "data"): unknown => {
+      eventLog.push(`on:${eventName}`);
+      return undefined;
+    },
+    pause: (): unknown => {
+      eventLog.push("pause");
+      return undefined;
+    },
+    rawModes: (): ReadonlyArray<boolean> => rawModeLog,
+    resume: (): unknown => {
+      eventLog.push("resume");
+      return undefined;
+    },
+    setRawMode: supportsRawMode
+      ? (enabled: boolean): unknown => {
+          rawModeLog.push(enabled);
+          return undefined;
+        }
+      : undefined,
+  };
+
+  return processInput;
+};
+
+test("wraps process-like input behind the text input port", (): void => {
+  const processInput = createFakeProcessInput(true);
+  const textInput = createTextInput(processInput);
+
+  assert.equal(textInput.resume(), textInput);
+  assert.equal(textInput.on("data", ignoreInput), textInput);
+  assert.equal(textInput.setRawMode?.(true), textInput);
+  assert.equal(textInput.off("data", ignoreInput), textInput);
+  assert.equal(textInput.pause(), textInput);
+  assert.deepEqual(processInput.rawModes(), [true]);
+  assert.deepEqual(processInput.eventLog(), [
+    "resume",
+    "on:data",
+    "off:data",
+    "pause",
+  ]);
+});
+
+test("skips adapted process raw mode when it is unavailable", (): void => {
+  const lineInput = createFakeProcessInput(false);
+  const missingRawInput = createFakeProcessInput(true, false);
+
+  createTextInput(lineInput).setRawMode?.(true);
+  createTextInput(missingRawInput).setRawMode?.(true);
+
+  assert.deepEqual(lineInput.rawModes(), []);
+  assert.deepEqual(missingRawInput.rawModes(), []);
+});
+
+test("detects whether the CLI module is the process entrypoint", (): void => {
+  const entryPath = "/tmp/bruff-cli.ts";
+  const moduleUrl = pathToFileURL(entryPath).href;
+
+  assert.equal(isCliEntryPoint(["node", entryPath], moduleUrl), true);
+  assert.equal(isCliEntryPoint(["node", "/tmp/other.ts"], moduleUrl), false);
+  assert.equal(isCliEntryPoint(["node"], moduleUrl), false);
+});
+
+test("renders through process-like ports", (): void => {
+  const input = createFakeProcessInput(true);
+  const writer: TextWriter = {
+    write: (): boolean => true,
+  };
+
+  assert.deepEqual(runBruffCliWithProcess({ input, writer }), { type: "ok" });
+  assert.deepEqual(input.rawModes(), [true]);
+  assert.deepEqual(input.eventLog(), ["resume", "on:data"]);
+});
+
+test("uses resumed line input when raw mode is unsupported on a tty", (): void => {
+  const input = createFakeInput(true, false);
+  const writer: TextWriter = {
+    write: (): boolean => true,
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  assert.deepEqual(input.rawModes(), []);
+  assert.equal(input.hasListener(), true);
+  assert.equal(input.isPaused(), false);
+
+  input.emit("q");
+
+  assert.deepEqual(input.rawModes(), []);
+  assert.equal(input.hasListener(), false);
+  assert.equal(input.isPaused(), true);
+});
+
+test("keeps terminal input active for ordinary keys", (): void => {
+  const input = createFakeInput(true);
+  const writer: TextWriter = {
+    write: (): boolean => true,
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  input.emit("x");
+
+  assert.deepEqual(input.rawModes(), [true]);
+  assert.equal(input.hasListener(), true);
+  assert.equal(input.isPaused(), false);
+});
 
 test("renders the mock scene through an injected writer", (): void => {
   const input = createFakeInput(true);

--- a/packages/cli/bin/bruff-cli.test.ts
+++ b/packages/cli/bin/bruff-cli.test.ts
@@ -1,0 +1,162 @@
+import * as assert from "node:assert/strict";
+
+import {
+  runBruffCli,
+  type TextInput,
+  type TextInputChunk,
+} from "./bruff-cli.ts";
+import { test } from "node:test";
+import type { TextWriter } from "../module/write-frame.ts";
+
+const ansiCursorPrefix = "\u001B[2;3H";
+const ansiClearPrefix = "\u001B[2J";
+const ansiForegroundPrefix = "\u001B[38;2;";
+const ansiBackgroundPrefix = "\u001B[48;2;";
+const ansiResetSuffix = "\u001B[0m";
+const controlCShortcut = "\u0003";
+const expectedSingleWrite = 1;
+
+type FakeInput = TextInput &
+  Readonly<{
+    emit: (chunk: TextInputChunk) => void;
+    hasListener: () => boolean;
+    isPaused: () => boolean;
+    rawModes: () => ReadonlyArray<boolean>;
+  }>;
+
+const ignoreInput = (chunk: TextInputChunk): void => {
+  chunk.toString();
+};
+
+const createFakeInput = (isTTY: boolean): FakeInput => {
+  const rawModeLog: Array<boolean> = [];
+  let dataListener: (chunk: TextInputChunk) => void = ignoreInput;
+  let paused = true;
+
+  const input: FakeInput = {
+    emit: (chunk: TextInputChunk): void => {
+      dataListener(chunk);
+    },
+    hasListener: (): boolean => dataListener !== ignoreInput,
+    isPaused: (): boolean => paused,
+    isTTY,
+    off: (
+      _eventName: "data",
+      listener: (chunk: TextInputChunk) => void,
+    ): TextInput => {
+      if (dataListener === listener) {
+        dataListener = ignoreInput;
+      }
+
+      return input;
+    },
+    on: (
+      _eventName: "data",
+      listener: (chunk: TextInputChunk) => void,
+    ): TextInput => {
+      dataListener = listener;
+      return input;
+    },
+    pause: (): TextInput => {
+      paused = true;
+      return input;
+    },
+    rawModes: (): ReadonlyArray<boolean> => rawModeLog,
+    resume: (): TextInput => {
+      paused = false;
+      return input;
+    },
+    setRawMode: (enabled: boolean): TextInput => {
+      rawModeLog.push(enabled);
+      return input;
+    },
+  };
+
+  return input;
+};
+
+test("renders the mock scene through an injected writer", (): void => {
+  const input = createFakeInput(true);
+  const writtenTexts: Array<string> = [];
+  const writer: TextWriter = {
+    write: (text: string): boolean => {
+      writtenTexts.push(text);
+      return true;
+    },
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  assert.deepEqual(writtenTexts, [writtenTexts.join("")]);
+  assert.equal(writtenTexts.join("").startsWith(ansiClearPrefix), true);
+  assert.equal(writtenTexts.join("").includes(ansiCursorPrefix), true);
+  assert.equal(writtenTexts.join("").includes(ansiForegroundPrefix), true);
+  assert.equal(writtenTexts.join("").includes(ansiBackgroundPrefix), true);
+  assert.equal(writtenTexts.join("").endsWith(ansiResetSuffix), true);
+});
+
+test("waits for a quit shortcut before releasing terminal input", (): void => {
+  const input = createFakeInput(true);
+  const writer: TextWriter = {
+    write: (): boolean => true,
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  assert.deepEqual(input.rawModes(), [true]);
+  assert.equal(input.hasListener(), true);
+  assert.equal(input.isPaused(), false);
+
+  input.emit("q");
+
+  assert.deepEqual(input.rawModes(), [true, false]);
+  assert.equal(input.hasListener(), false);
+  assert.equal(input.isPaused(), true);
+});
+
+test("does not wait for input when rendering fails", (): void => {
+  const input = createFakeInput(true);
+  const writer: TextWriter = {
+    write: (): boolean => false,
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), {
+    reason: "write-failed",
+    type: "error",
+  });
+  assert.deepEqual(input.rawModes(), []);
+  assert.equal(input.hasListener(), false);
+  assert.equal(input.isPaused(), true);
+});
+
+test("uses resumed line input when raw mode is unavailable", (): void => {
+  const input = createFakeInput(false);
+  const writer: TextWriter = {
+    write: (): boolean => true,
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  assert.deepEqual(input.rawModes(), []);
+  assert.equal(input.hasListener(), true);
+  assert.equal(input.isPaused(), false);
+
+  input.emit("Q");
+
+  assert.deepEqual(input.rawModes(), []);
+  assert.equal(input.hasListener(), false);
+  assert.equal(input.isPaused(), true);
+});
+
+test("writes the scene once while waiting for input", (): void => {
+  const input = createFakeInput(true);
+  const writtenTexts: Array<string> = [];
+  const writer: TextWriter = {
+    write: (text: string): boolean => {
+      writtenTexts.push(text);
+      return true;
+    },
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  input.emit(controlCShortcut);
+
+  assert.equal(writtenTexts.length, expectedSingleWrite);
+});

--- a/packages/cli/bin/bruff-cli.ts
+++ b/packages/cli/bin/bruff-cli.ts
@@ -1,0 +1,165 @@
+import {
+  type TextWriter,
+  type WriteFrameResult,
+  writeTerminalFrame,
+} from "../module/write-frame.ts";
+import { createMockTerminalFrame } from "../module/mock-scene.ts";
+import { pathToFileURL } from "node:url";
+
+const controlCShortcut = "\u0003";
+const lowercaseQuitShortcut = "q";
+const uppercaseQuitShortcut = "Q";
+
+/**
+ * Text input chunk received from the terminal.
+ */
+export type TextInputChunk = Buffer | string;
+
+/**
+ * Minimal stdin-like input used by the CLI session.
+ */
+export type TextInput = Readonly<{
+  /**
+   * Whether the input supports terminal raw mode.
+   */
+  isTTY?: boolean;
+  /**
+   * Stop reading input.
+   */
+  pause: () => TextInput;
+  /**
+   * Start reading input.
+   */
+  resume: () => TextInput;
+  /**
+   * Enable or disable terminal raw mode.
+   */
+  setRawMode?: (enabled: boolean) => TextInput;
+  /**
+   * Register an input listener.
+   */
+  on: (
+    eventName: "data",
+    listener: (chunk: TextInputChunk) => void,
+  ) => TextInput;
+  /**
+   * Remove an input listener.
+   */
+  off: (
+    eventName: "data",
+    listener: (chunk: TextInputChunk) => void,
+  ) => TextInput;
+}>;
+
+/**
+ * Input and output ports for the CLI session.
+ */
+export type BruffCliPorts = Readonly<{
+  /**
+   * Terminal input.
+   */
+  input: TextInput;
+  /**
+   * Terminal output.
+   */
+  writer: TextWriter;
+}>;
+
+const isQuitShortcut = (text: string): boolean =>
+  text.includes(lowercaseQuitShortcut) ||
+  text.includes(uppercaseQuitShortcut) ||
+  text.includes(controlCShortcut);
+
+const enableRawMode = (input: TextInput): TextInput =>
+  input.isTTY === true && input.setRawMode !== undefined
+    ? input.setRawMode(true).resume()
+    : input.resume();
+
+const disableRawMode = (input: TextInput): TextInput =>
+  input.isTTY === true && input.setRawMode !== undefined
+    ? input.setRawMode(false).pause()
+    : input.pause();
+
+const createProcessInput = (): TextInput => {
+  const input: TextInput = {
+    isTTY: process.stdin.isTTY,
+    off: (
+      eventName: "data",
+      listener: (chunk: TextInputChunk) => void,
+    ): TextInput => {
+      process.stdin.off(eventName, listener);
+      return input;
+    },
+    on: (
+      eventName: "data",
+      listener: (chunk: TextInputChunk) => void,
+    ): TextInput => {
+      process.stdin.on(eventName, listener);
+      return input;
+    },
+    pause: (): TextInput => {
+      process.stdin.pause();
+      return input;
+    },
+    resume: (): TextInput => {
+      process.stdin.resume();
+      return input;
+    },
+    setRawMode: (enabled: boolean): TextInput => {
+      if (process.stdin.isTTY === true) {
+        process.stdin.setRawMode(enabled);
+      }
+
+      return input;
+    },
+  };
+
+  return input;
+};
+
+/**
+ * Render the deterministic mock scene and wait for a quit shortcut.
+ */
+export const runBruffCli = (ports: BruffCliPorts): WriteFrameResult => {
+  const writeResult = writeTerminalFrame(
+    ports.writer,
+    createMockTerminalFrame(),
+  );
+
+  if (writeResult.type === "error") {
+    return writeResult;
+  }
+
+  const handleInput = (chunk: TextInputChunk): void => {
+    if (isQuitShortcut(chunk.toString())) {
+      ports.input.off("data", handleInput);
+      disableRawMode(ports.input);
+    }
+  };
+
+  enableRawMode(ports.input).on("data", handleInput);
+
+  return writeResult;
+};
+
+const isCliEntryPoint = (
+  argv: ReadonlyArray<string>,
+  moduleUrl: string,
+): boolean => {
+  const [, entryPath] = argv;
+
+  return entryPath === undefined
+    ? false
+    : pathToFileURL(entryPath).href === moduleUrl;
+};
+
+if (isCliEntryPoint(process.argv, import.meta.url)) {
+  const writeResult = runBruffCli({
+    input: createProcessInput(),
+    writer: process.stdout,
+  });
+
+  if (writeResult.type === "error") {
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/bin/bruff-cli.ts
+++ b/packages/cli/bin/bruff-cli.ts
@@ -52,6 +52,39 @@ export type TextInput = Readonly<{
 }>;
 
 /**
+ * Process stdin shape adapted into the CLI text input port.
+ */
+export type ProcessTextInput = Readonly<{
+  /**
+   * Whether the process input supports terminal behaviour.
+   */
+  isTTY?: boolean;
+  /**
+   * Remove an input listener.
+   */
+  off: (
+    eventName: "data",
+    listener: (chunk: TextInputChunk) => void,
+  ) => unknown;
+  /**
+   * Register an input listener.
+   */
+  on: (eventName: "data", listener: (chunk: TextInputChunk) => void) => unknown;
+  /**
+   * Stop reading input.
+   */
+  pause: () => unknown;
+  /**
+   * Start reading input.
+   */
+  resume: () => unknown;
+  /**
+   * Enable or disable terminal raw mode.
+   */
+  setRawMode?: (enabled: boolean) => unknown;
+}>;
+
+/**
  * Input and output ports for the CLI session.
  */
 export type BruffCliPorts = Readonly<{
@@ -61,6 +94,20 @@ export type BruffCliPorts = Readonly<{
   input: TextInput;
   /**
    * Terminal output.
+   */
+  writer: TextWriter;
+}>;
+
+/**
+ * Process input and output ports used by the executable CLI wrapper.
+ */
+export type BruffCliProcessPorts = Readonly<{
+  /**
+   * Process terminal input.
+   */
+  input: ProcessTextInput;
+  /**
+   * Process terminal output.
    */
   writer: TextWriter;
 }>;
@@ -80,34 +127,37 @@ const disableRawMode = (input: TextInput): TextInput =>
     ? input.setRawMode(false).pause()
     : input.pause();
 
-const createProcessInput = (): TextInput => {
+/**
+ * Adapt a process-like input stream into the CLI text input port.
+ */
+export const createTextInput = (source: ProcessTextInput): TextInput => {
   const input: TextInput = {
-    isTTY: process.stdin.isTTY,
+    isTTY: source.isTTY,
     off: (
       eventName: "data",
       listener: (chunk: TextInputChunk) => void,
     ): TextInput => {
-      process.stdin.off(eventName, listener);
+      source.off(eventName, listener);
       return input;
     },
     on: (
       eventName: "data",
       listener: (chunk: TextInputChunk) => void,
     ): TextInput => {
-      process.stdin.on(eventName, listener);
+      source.on(eventName, listener);
       return input;
     },
     pause: (): TextInput => {
-      process.stdin.pause();
+      source.pause();
       return input;
     },
     resume: (): TextInput => {
-      process.stdin.resume();
+      source.resume();
       return input;
     },
     setRawMode: (enabled: boolean): TextInput => {
-      if (process.stdin.isTTY === true) {
-        process.stdin.setRawMode(enabled);
+      if (source.isTTY === true && source.setRawMode !== undefined) {
+        source.setRawMode(enabled);
       }
 
       return input;
@@ -142,7 +192,10 @@ export const runBruffCli = (ports: BruffCliPorts): WriteFrameResult => {
   return writeResult;
 };
 
-const isCliEntryPoint = (
+/**
+ * Determine whether this module is being executed as the process entrypoint.
+ */
+export const isCliEntryPoint = (
   argv: ReadonlyArray<string>,
   moduleUrl: string,
 ): boolean => {
@@ -153,9 +206,21 @@ const isCliEntryPoint = (
     : pathToFileURL(entryPath).href === moduleUrl;
 };
 
+/**
+ * Render the CLI using process-like ports.
+ */
+export const runBruffCliWithProcess = (
+  ports: BruffCliProcessPorts,
+): WriteFrameResult =>
+  runBruffCli({
+    input: createTextInput(ports.input),
+    writer: ports.writer,
+  });
+
+/* node:coverage ignore next 10 */
 if (isCliEntryPoint(process.argv, import.meta.url)) {
-  const writeResult = runBruffCli({
-    input: createProcessInput(),
+  const writeResult = runBruffCliWithProcess({
+    input: process.stdin,
     writer: process.stdout,
   });
 

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -1,0 +1,8 @@
+import bruffEslintConfig from "@bruff/eslint-config";
+
+export default [
+  {
+    ignores: ["coverage/**/*.*"],
+  },
+  ...bruffEslintConfig,
+];

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,0 +1,12 @@
+export { encodeAnsiCommand, encodeAnsiCommands } from "./module/ansi.ts";
+export { createMockTerminalFrame } from "./module/mock-scene.ts";
+export { renderTerminalFrame } from "./module/render-frame.ts";
+export { writeTerminalFrame } from "./module/write-frame.ts";
+export type { AnsiCommand } from "./module/ansi.ts";
+export type {
+  TerminalCell,
+  TerminalColor,
+  TerminalFrame,
+  TerminalPosition,
+} from "./module/terminal-cell.ts";
+export type { TextWriter, WriteFrameResult } from "./module/write-frame.ts";

--- a/packages/cli/module/ansi.test.ts
+++ b/packages/cli/module/ansi.test.ts
@@ -1,0 +1,65 @@
+import * as assert from "node:assert/strict";
+
+import { encodeAnsiCommand, encodeAnsiCommands } from "./ansi.ts";
+import { test } from "node:test";
+
+test("encodes screen clearing", (): void => {
+  assert.equal(encodeAnsiCommand({ type: "clear-screen" }), "\u001B[2J");
+});
+
+test("encodes cursor movement with row and column", (): void => {
+  assert.equal(
+    encodeAnsiCommand({
+      position: { column: 7, row: 3 },
+      type: "cursor-move",
+    }),
+    "\u001B[3;7H",
+  );
+});
+
+test("encodes truecolor foreground colors", (): void => {
+  assert.equal(
+    encodeAnsiCommand({
+      color: { blue: 56, green: 34, red: 12 },
+      type: "set-foreground",
+    }),
+    "\u001B[38;2;12;34;56m",
+  );
+});
+
+test("encodes truecolor background colors", (): void => {
+  assert.equal(
+    encodeAnsiCommand({
+      color: { blue: 220, green: 160, red: 40 },
+      type: "set-background",
+    }),
+    "\u001B[48;2;40;160;220m",
+  );
+});
+
+test("encodes glyph writes without modifying the glyph", (): void => {
+  assert.equal(
+    encodeAnsiCommand({
+      glyph: "ᚠ",
+      type: "write-glyph",
+    }),
+    "ᚠ",
+  );
+});
+
+test("encodes style reset", (): void => {
+  assert.equal(encodeAnsiCommand({ type: "reset-style" }), "\u001B[0m");
+});
+
+test("encodes command sequences in order", (): void => {
+  assert.equal(
+    encodeAnsiCommands([
+      { type: "clear-screen" },
+      { position: { column: 2, row: 1 }, type: "cursor-move" },
+      { color: { blue: 3, green: 2, red: 1 }, type: "set-foreground" },
+      { glyph: "@", type: "write-glyph" },
+      { type: "reset-style" },
+    ]),
+    "\u001B[2J\u001B[1;2H\u001B[38;2;1;2;3m@\u001B[0m",
+  );
+});

--- a/packages/cli/module/ansi.ts
+++ b/packages/cli/module/ansi.ts
@@ -1,0 +1,55 @@
+import type { TerminalColor, TerminalPosition } from "./terminal-cell.ts";
+
+const encodeColor = (mode: "38" | "48", color: TerminalColor): string =>
+  `\u001B[${mode};2;${color.red};${color.green};${color.blue}m`;
+
+const encodeCursorMove = (position: TerminalPosition): string =>
+  `\u001B[${position.row};${position.column}H`;
+
+/**
+ * Terminal command encoded as ANSI text before writing.
+ */
+export type AnsiCommand =
+  | Readonly<{ type: "clear-screen" }>
+  | Readonly<{ position: TerminalPosition; type: "cursor-move" }>
+  | Readonly<{ type: "reset-style" }>
+  | Readonly<{ color: TerminalColor; type: "set-background" }>
+  | Readonly<{ color: TerminalColor; type: "set-foreground" }>
+  | Readonly<{ glyph: string; type: "write-glyph" }>;
+
+/**
+ * Encode one terminal command as ANSI text.
+ */
+export const encodeAnsiCommand = (command: AnsiCommand): string => {
+  switch (command.type) {
+    case "clear-screen": {
+      return "\u001B[2J";
+    }
+    case "cursor-move": {
+      return encodeCursorMove(command.position);
+    }
+    case "reset-style": {
+      return "\u001B[0m";
+    }
+    case "set-background": {
+      return encodeColor("48", command.color);
+    }
+    case "set-foreground": {
+      return encodeColor("38", command.color);
+    }
+    case "write-glyph": {
+      return command.glyph;
+    }
+    default: {
+      const _exhaustive: never = command;
+      return _exhaustive;
+    }
+  }
+};
+
+/**
+ * Encode terminal commands as one ANSI text chunk.
+ */
+export const encodeAnsiCommands = (
+  commands: ReadonlyArray<AnsiCommand>,
+): string => commands.map((command) => encodeAnsiCommand(command)).join("");

--- a/packages/cli/module/ansi.ts
+++ b/packages/cli/module/ansi.ts
@@ -40,6 +40,7 @@ export const encodeAnsiCommand = (command: AnsiCommand): string => {
     case "write-glyph": {
       return command.glyph;
     }
+    /* node:coverage ignore next 5 */
     default: {
       const _exhaustive: never = command;
       return _exhaustive;

--- a/packages/cli/module/mock-scene.test.ts
+++ b/packages/cli/module/mock-scene.test.ts
@@ -1,0 +1,55 @@
+import * as assert from "node:assert/strict";
+
+import { ASCII, RUNIC } from "@bruff/glyph";
+
+import { createMockTerminalFrame } from "./mock-scene.ts";
+import type { TerminalColor } from "./terminal-cell.ts";
+import { test } from "node:test";
+
+const colorKey = (color: TerminalColor): string =>
+  `${color.red},${color.green},${color.blue}`;
+
+const countDistinctColors = (colors: ReadonlyArray<TerminalColor>): number =>
+  new Set(colors.map((color) => colorKey(color))).size;
+
+const distinctColorKeys = (
+  colors: ReadonlyArray<TerminalColor>,
+): ReadonlyArray<string> => [
+  ...new Set(colors.map((color) => colorKey(color))),
+];
+
+const expectedBackgroundColorKeys = ["24,24,24", "40,40,40", "72,28,20"];
+
+const expectedForegroundColorKeys = [
+  "230,230,230",
+  "150,150,150",
+  "255,210,64",
+  "255,90,80",
+  "120,120,180",
+];
+
+test("creates a deterministic scene using glyph catalog characters", (): void => {
+  const frame = createMockTerminalFrame();
+
+  assert.deepEqual(
+    frame.cells.map((cell) => cell.glyph),
+    [ASCII.AT, ASCII.HASH, ASCII.DOLLAR, ASCII.CARET, RUNIC.FEHU],
+  );
+});
+
+test("creates a scene with multiple foreground and background colors", (): void => {
+  const frame = createMockTerminalFrame();
+
+  assert.deepEqual(
+    distinctColorKeys(frame.cells.map((cell) => cell.foregroundColor)),
+    expectedForegroundColorKeys,
+  );
+  assert.deepEqual(
+    distinctColorKeys(frame.cells.map((cell) => cell.backgroundColor)),
+    expectedBackgroundColorKeys,
+  );
+  assert.equal(
+    countDistinctColors(frame.cells.map((cell) => cell.foregroundColor)),
+    frame.cells.length,
+  );
+});

--- a/packages/cli/module/mock-scene.ts
+++ b/packages/cli/module/mock-scene.ts
@@ -1,0 +1,41 @@
+import { ASCII, RUNIC } from "@bruff/glyph";
+
+import type { TerminalFrame } from "./terminal-cell.ts";
+
+/**
+ * Create the deterministic mock frame used by the terminal renderer spike.
+ */
+export const createMockTerminalFrame = (): TerminalFrame => ({
+  cells: [
+    {
+      backgroundColor: { blue: 24, green: 24, red: 24 },
+      foregroundColor: { blue: 230, green: 230, red: 230 },
+      glyph: ASCII.AT,
+      position: { column: 3, row: 2 },
+    },
+    {
+      backgroundColor: { blue: 40, green: 40, red: 40 },
+      foregroundColor: { blue: 150, green: 150, red: 150 },
+      glyph: ASCII.HASH,
+      position: { column: 4, row: 2 },
+    },
+    {
+      backgroundColor: { blue: 24, green: 24, red: 24 },
+      foregroundColor: { blue: 64, green: 210, red: 255 },
+      glyph: ASCII.DOLLAR,
+      position: { column: 5, row: 2 },
+    },
+    {
+      backgroundColor: { blue: 20, green: 28, red: 72 },
+      foregroundColor: { blue: 80, green: 90, red: 255 },
+      glyph: ASCII.CARET,
+      position: { column: 3, row: 3 },
+    },
+    {
+      backgroundColor: { blue: 24, green: 24, red: 24 },
+      foregroundColor: { blue: 180, green: 120, red: 120 },
+      glyph: RUNIC.FEHU,
+      position: { column: 5, row: 3 },
+    },
+  ],
+});

--- a/packages/cli/module/render-frame.test.ts
+++ b/packages/cli/module/render-frame.test.ts
@@ -1,0 +1,69 @@
+import * as assert from "node:assert/strict";
+
+import { renderTerminalFrame } from "./render-frame.ts";
+import type { TerminalFrame } from "./terminal-cell.ts";
+import { test } from "node:test";
+
+test("renders cursor, colors, and glyph commands for each cell", (): void => {
+  const frame: TerminalFrame = {
+    cells: [
+      {
+        backgroundColor: { blue: 30, green: 20, red: 10 },
+        foregroundColor: { blue: 3, green: 2, red: 1 },
+        glyph: "@",
+        position: { column: 4, row: 2 },
+      },
+    ],
+  };
+
+  assert.deepEqual(renderTerminalFrame(frame), [
+    { type: "clear-screen" },
+    { position: { column: 4, row: 2 }, type: "cursor-move" },
+    { color: { blue: 3, green: 2, red: 1 }, type: "set-foreground" },
+    { color: { blue: 30, green: 20, red: 10 }, type: "set-background" },
+    { glyph: "@", type: "write-glyph" },
+    { position: { column: 1, row: 4 }, type: "cursor-move" },
+    { type: "reset-style" },
+  ]);
+});
+
+test("renders cells in frame order with one final reset", (): void => {
+  const frame: TerminalFrame = {
+    cells: [
+      {
+        backgroundColor: { blue: 6, green: 5, red: 4 },
+        foregroundColor: { blue: 3, green: 2, red: 1 },
+        glyph: "#",
+        position: { column: 1, row: 1 },
+      },
+      {
+        backgroundColor: { blue: 12, green: 11, red: 10 },
+        foregroundColor: { blue: 9, green: 8, red: 7 },
+        glyph: "$",
+        position: { column: 2, row: 1 },
+      },
+    ],
+  };
+
+  assert.deepEqual(renderTerminalFrame(frame), [
+    { type: "clear-screen" },
+    { position: { column: 1, row: 1 }, type: "cursor-move" },
+    { color: { blue: 3, green: 2, red: 1 }, type: "set-foreground" },
+    { color: { blue: 6, green: 5, red: 4 }, type: "set-background" },
+    { glyph: "#", type: "write-glyph" },
+    { position: { column: 2, row: 1 }, type: "cursor-move" },
+    { color: { blue: 9, green: 8, red: 7 }, type: "set-foreground" },
+    { color: { blue: 12, green: 11, red: 10 }, type: "set-background" },
+    { glyph: "$", type: "write-glyph" },
+    { position: { column: 1, row: 3 }, type: "cursor-move" },
+    { type: "reset-style" },
+  ]);
+});
+
+test("renders an empty frame as a style reset", (): void => {
+  assert.deepEqual(renderTerminalFrame({ cells: [] }), [
+    { type: "clear-screen" },
+    { position: { column: 1, row: 1 }, type: "cursor-move" },
+    { type: "reset-style" },
+  ]);
+});

--- a/packages/cli/module/render-frame.ts
+++ b/packages/cli/module/render-frame.ts
@@ -1,0 +1,33 @@
+import type { TerminalCell, TerminalFrame } from "./terminal-cell.ts";
+import type { AnsiCommand } from "./ansi.ts";
+
+const emptyFrameCursorRow = 1;
+const firstTerminalColumn = 1;
+const promptRowPadding = 2;
+
+const getPromptPosition = (frame: TerminalFrame): TerminalCell["position"] => ({
+  column: firstTerminalColumn,
+  row: Math.max(
+    emptyFrameCursorRow,
+    ...frame.cells.map((cell) => cell.position.row + promptRowPadding),
+  ),
+});
+
+const renderTerminalCell = (cell: TerminalCell): ReadonlyArray<AnsiCommand> => [
+  { position: cell.position, type: "cursor-move" },
+  { color: cell.foregroundColor, type: "set-foreground" },
+  { color: cell.backgroundColor, type: "set-background" },
+  { glyph: cell.glyph, type: "write-glyph" },
+];
+
+/**
+ * Convert a terminal frame into ANSI commands.
+ */
+export const renderTerminalFrame = (
+  frame: TerminalFrame,
+): ReadonlyArray<AnsiCommand> => [
+  { type: "clear-screen" },
+  ...frame.cells.flatMap((cell) => renderTerminalCell(cell)),
+  { position: getPromptPosition(frame), type: "cursor-move" },
+  { type: "reset-style" },
+];

--- a/packages/cli/module/terminal-cell.ts
+++ b/packages/cli/module/terminal-cell.ts
@@ -1,0 +1,63 @@
+/**
+ * Truecolor terminal color channel values.
+ */
+export type TerminalColor = Readonly<{
+  /**
+   * Blue channel from 0 to 255.
+   */
+  blue: number;
+  /**
+   * Green channel from 0 to 255.
+   */
+  green: number;
+  /**
+   * Red channel from 0 to 255.
+   */
+  red: number;
+}>;
+
+/**
+ * One-based terminal cursor position.
+ */
+export type TerminalPosition = Readonly<{
+  /**
+   * One-based terminal column.
+   */
+  column: number;
+  /**
+   * One-based terminal row.
+   */
+  row: number;
+}>;
+
+/**
+ * A single positioned text cell in a terminal frame.
+ */
+export type TerminalCell = Readonly<{
+  /**
+   * Cell background color.
+   */
+  backgroundColor: TerminalColor;
+  /**
+   * Cell foreground color.
+   */
+  foregroundColor: TerminalColor;
+  /**
+   * Text glyph written at the cell position.
+   */
+  glyph: string;
+  /**
+   * Cell cursor position.
+   */
+  position: TerminalPosition;
+}>;
+
+/**
+ * A complete terminal frame expressed as positioned cells.
+ */
+export type TerminalFrame = Readonly<{
+  /**
+   * Cells to render.
+   */
+  cells: ReadonlyArray<TerminalCell>;
+}>;

--- a/packages/cli/module/write-frame.test.ts
+++ b/packages/cli/module/write-frame.test.ts
@@ -1,0 +1,55 @@
+import * as assert from "node:assert/strict";
+
+import { type TextWriter, writeTerminalFrame } from "./write-frame.ts";
+import type { TerminalFrame } from "./terminal-cell.ts";
+import { test } from "node:test";
+
+const frame: TerminalFrame = {
+  cells: [
+    {
+      backgroundColor: { blue: 6, green: 5, red: 4 },
+      foregroundColor: { blue: 3, green: 2, red: 1 },
+      glyph: "@",
+      position: { column: 2, row: 1 },
+    },
+  ],
+};
+
+test("writes encoded frame text to the injected writer", (): void => {
+  const writtenTexts: Array<string> = [];
+  const writer: TextWriter = {
+    write: (text: string): boolean => {
+      writtenTexts.push(text);
+      return true;
+    },
+  };
+
+  assert.deepEqual(writeTerminalFrame(writer, frame), { type: "ok" });
+  assert.deepEqual(writtenTexts, [
+    "\u001B[2J\u001B[1;2H\u001B[38;2;1;2;3m\u001B[48;2;4;5;6m@\u001B[3;1H\u001B[0m",
+  ]);
+});
+
+test("returns a write-failed error when the writer returns false", (): void => {
+  const writer: TextWriter = {
+    write: (): boolean => false,
+  };
+
+  assert.deepEqual(writeTerminalFrame(writer, frame), {
+    reason: "write-failed",
+    type: "error",
+  });
+});
+
+test("returns a write-threw error when the writer throws", (): void => {
+  const writer: TextWriter = {
+    write: (): boolean => {
+      throw new Error("writer failed");
+    },
+  };
+
+  assert.deepEqual(writeTerminalFrame(writer, frame), {
+    reason: "write-threw",
+    type: "error",
+  });
+});

--- a/packages/cli/module/write-frame.ts
+++ b/packages/cli/module/write-frame.ts
@@ -1,0 +1,46 @@
+import { encodeAnsiCommands } from "./ansi.ts";
+import { renderTerminalFrame } from "./render-frame.ts";
+import type { TerminalFrame } from "./terminal-cell.ts";
+
+/**
+ * Minimal stdout-like writer for terminal text.
+ */
+export type TextWriter = Readonly<{
+  /**
+   * Write text and report whether the destination accepted it.
+   */
+  write: (text: string) => boolean;
+}>;
+
+/**
+ * Result of writing a terminal frame.
+ */
+export type WriteFrameResult =
+  | Readonly<{ type: "ok" }>
+  | Readonly<{ reason: "write-failed" | "write-threw"; type: "error" }>;
+
+const failedWriteResult: WriteFrameResult = {
+  reason: "write-failed",
+  type: "error",
+};
+
+const threwWriteResult: WriteFrameResult = {
+  reason: "write-threw",
+  type: "error",
+};
+
+/**
+ * Render and write a terminal frame to an injected text writer.
+ */
+export const writeTerminalFrame = (
+  writer: TextWriter,
+  frame: TerminalFrame,
+): WriteFrameResult => {
+  const ansiText = encodeAnsiCommands(renderTerminalFrame(frame));
+
+  try {
+    return writer.write(ansiText) ? { type: "ok" } : failedWriteResult;
+  } catch {
+    return threwWriteResult;
+  }
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@bruff/cli",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Terminal ANSI renderer spike for Bruff mock scenes.",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+    "@bruff/glyph": "workspace:0.0.0"
+  },
+  "scripts": {
+    "cli": "node bin/bruff-cli.ts",
+    "format": "prettier --write .",
+    "lint": "eslint",
+    "test": "node --test \"**/*.test.ts\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@bruff/eslint-config": "workspace:0.0.0",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "cli": "node bin/bruff-cli.ts",
     "format": "prettier --write .",
     "lint": "eslint",
-    "test": "node --test \"**/*.test.ts\"",
+    "test": "node --experimental-test-coverage --test-coverage-exclude=\"../glyph/**/*.ts\" --test-coverage-exclude=\"**/*.test.ts\" --test \"**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+    "strict": true,
+    "target": "esnext",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.ts", "module/**/*.ts", "bin/**/*.ts"],
+  "exclude": ["node_modules", "eslint.config.js"]
+}

--- a/packages/eslint-config/rules.js
+++ b/packages/eslint-config/rules.js
@@ -72,7 +72,7 @@ export const overrideRulesEslint = {
     "error",
     "always",
     {
-      ignorePattern: "c8 ignore",
+      ignorePattern: "(?:c8|node:coverage) ignore",
     },
   ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
+    '@types/node':
+      specifier: 24.0.0
+      version: 24.0.0
     '@vitest/browser':
       specifier: 4.1.4
       version: 4.1.4
@@ -85,7 +88,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: 'catalog:'
-        version: 2.31.0
+        version: 2.31.0(@types/node@24.0.0)
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -130,10 +133,32 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14
+        version: 8.0.14(@types/node@24.0.0)
       vite-plugin-istanbul:
         specifier: 'catalog:'
-        version: 8.0.0(vite@8.0.14)
+        version: 8.0.0(vite@8.0.14(@types/node@24.0.0))
+
+  packages/cli:
+    dependencies:
+      '@bruff/glyph':
+        specifier: workspace:0.0.0
+        version: link:../glyph
+    devDependencies:
+      '@bruff/eslint-config':
+        specifier: workspace:0.0.0
+        version: link:../eslint-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.0.0
+      eslint:
+        specifier: 'catalog:'
+        version: 10.4.0
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.3
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/eslint-config:
     dependencies:
@@ -178,10 +203,10 @@ importers:
         version: 0.4.1(vitest@4.1.4)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.4(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -205,13 +230,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14
+        version: 8.0.14(@types/node@24.0.0)
       vite-plugin-istanbul:
         specifier: 'catalog:'
-        version: 8.0.0(vite@8.0.14)
+        version: 8.0.0(vite@8.0.14(@types/node@24.0.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+        version: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
   packages/game-element:
     dependencies:
@@ -224,10 +249,10 @@ importers:
         version: link:../eslint-config
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.4(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -248,7 +273,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+        version: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
   packages/glyph:
     devDependencies:
@@ -257,10 +282,10 @@ importers:
         version: link:../eslint-config
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.4(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -281,7 +306,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+        version: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
   packages/sigil:
     dependencies:
@@ -300,10 +325,10 @@ importers:
         version: 1.3.9
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.4(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -324,7 +349,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+        version: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
   packages/utils:
     devDependencies:
@@ -333,10 +358,10 @@ importers:
         version: link:../eslint-config
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.4(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+        version: 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -357,7 +382,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+        version: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
 packages:
 
@@ -774,6 +799,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==, tarball: https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz}
+
+  '@types/node@24.0.0':
+    resolution: {integrity: sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==, tarball: https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz}
 
   '@types/opentype.js@1.3.9':
     resolution: {integrity: sha512-KOGywvDPncA4/tTWV5xKNhjpsoSSAHIx3mHOhL5l3XX+c6Xu2dQnHvGs7mRNQsQRte1EqmQ0cPQQ8Z14lkv+yw==, tarball: https://registry.npmjs.org/@types/opentype.js/-/opentype.js-1.3.9.tgz}
@@ -2057,6 +2085,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==, tarball: https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz}
     engines: {node: '>= 4.0.0'}
@@ -2360,7 +2391,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0':
+  '@changesets/cli@2.31.0(@types/node@24.0.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -2376,7 +2407,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3
+      '@inquirer/external-editor': 1.0.3(@types/node@24.0.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -2536,7 +2567,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.4)':
     dependencies:
       fast-check: 4.8.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+      vitest: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2554,10 +2585,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3':
+  '@inquirer/external-editor@1.0.3(@types/node@24.0.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.0.0
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -2716,6 +2749,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/node@12.20.55': {}
+
+  '@types/node@24.0.0':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/opentype.js@1.3.9': {}
 
@@ -2876,29 +2913,29 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/browser-playwright@4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.14)(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(vite@8.0.14)
+      '@vitest/browser': 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@8.0.14(@types/node@24.0.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+      vitest: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(vite@8.0.14)(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(vite@8.0.14)
+      '@vitest/mocker': 4.1.4(vite@8.0.14(@types/node@24.0.0))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+      vitest: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -2918,9 +2955,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14)
+      vitest: 4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.14)(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -2931,13 +2968,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.14)':
+  '@vitest/mocker@4.1.4(vite@8.0.14(@types/node@24.0.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14
+      vite: 8.0.14(@types/node@24.0.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -4042,6 +4079,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.8.0: {}
+
   universalify@0.1.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -4056,7 +4095,7 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-plugin-istanbul@8.0.0(vite@8.0.14):
+  vite-plugin-istanbul@8.0.0(vite@8.0.14(@types/node@24.0.0)):
     dependencies:
       '@babel/generator': 7.29.1
       '@istanbuljs/load-nyc-config': 1.1.0
@@ -4066,11 +4105,11 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
       test-exclude: 8.0.0
-      vite: 8.0.14
+      vite: 8.0.14(@types/node@24.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.14:
+  vite@8.0.14(@types/node@24.0.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4078,12 +4117,13 @@ snapshots:
       rolldown: 1.0.2
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 24.0.0
       fsevents: 2.3.3
 
-  vitest@4.1.4(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14):
+  vitest@4.1.4(@types/node@24.0.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(vite@8.0.14(@types/node@24.0.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.14)
+      '@vitest/mocker': 4.1.4(vite@8.0.14(@types/node@24.0.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -4100,10 +4140,11 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.14
+      vite: 8.0.14(@types/node@24.0.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.4(playwright@1.60.0)(vite@8.0.14)(vitest@4.1.4)
+      '@types/node': 24.0.0
+      '@vitest/browser-playwright': 4.1.4(playwright@1.60.0)(vite@8.0.14(@types/node@24.0.0))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   "@eslint/js": 10.0.1
   "@fast-check/vitest": 0.4.1
   "@playwright/test": 1.60.0
+  "@types/node": 24.0.0
   "@vitest/browser": 4.1.4
   "@vitest/browser-playwright": 4.1.4
   "@vitest/coverage-v8": 4.1.4

--- a/specs/cli-ansi-renderer/acceptance.md
+++ b/specs/cli-ansi-renderer/acceptance.md
@@ -1,0 +1,17 @@
+# CLI ANSI Renderer — Acceptance
+
+- Running `pnpm --filter @bruff/cli run cli` writes ANSI text to stdout.
+- The CLI output begins with an ANSI clear-screen sequence.
+- The CLI output includes at least one cursor movement sequence such as `\x1b[<row>;<column>H`.
+- The CLI output includes at least one truecolor foreground sequence using `38;2`.
+- The CLI output includes at least one truecolor background sequence using `48;2`.
+- The CLI output includes at least three different glyphs sourced from `@bruff/glyph`.
+- The CLI output moves the cursor below the mock scene before the final ANSI reset sequence.
+- Running the CLI from an interactive terminal waits after drawing until the user presses `q`, `Q`, or `Ctrl+C`.
+- Running `printf q | pnpm --filter @bruff/cli run cli` exits normally after drawing and receiving the quit shortcut.
+- `packages/cli` runtime and test source imports no workspace package other than `@bruff/glyph`.
+- `packages/cli/eslint.config.js` imports and spreads the local shared `@bruff/eslint-config`.
+- No game-related package files are modified while implementing this spec.
+- `pnpm --filter @bruff/cli run test` runs native `node:test` TypeScript tests directly.
+- `pnpm --filter @bruff/cli run typecheck` succeeds without emitting JavaScript.
+- Tests cover ANSI encoding, mock scene composition, frame rendering, writer failures, executable entry boundary, raw-mode input setup, quit shortcuts, and writer failure before input registration.

--- a/specs/cli-ansi-renderer/constraints.md
+++ b/specs/cli-ansi-renderer/constraints.md
@@ -1,0 +1,21 @@
+# CLI ANSI Renderer — Constraints
+
+- Runtime source in `packages/cli` may import Node built-ins and `@bruff/glyph`.
+- Runtime source in `packages/cli` must not import any other workspace package.
+- Test source in `packages/cli` must not import any other workspace package except `@bruff/glyph`.
+- Package-local tooling config must import `@bruff/eslint-config` instead of duplicating lint rules.
+- `@bruff/eslint-config` is allowed only from `packages/cli/eslint.config.js` and package metadata.
+- `@bruff/glyph` is used only as a character catalog for rendered terminal cells.
+- No files in `packages/game`, `packages/game-element`, `packages/arcade`, `packages/sigil`, or `packages/utils` may be changed for this spec.
+- The CLI renders mock data only.
+- The CLI reads only the minimal quit shortcuts: `q`, `Q`, and `Ctrl+C`.
+- The CLI may enter raw terminal mode only while waiting for the quit shortcut, and must restore raw mode before pausing input.
+- The CLI does not read gameplay input, mutate game state, or start a game loop.
+- The CLI runs TypeScript directly through Node.js native TypeScript support.
+- No runtime transpiler or bundler is allowed: no `tsx`, `ts-node`, Babel, Vite, Vitest, Jest, or Playwright for `@bruff/cli`.
+- Tests use TypeScript files executed by Node's native test runner.
+- Tests import `node:test` and `node:assert/strict`.
+- TypeScript files use erasable syntax only: no `enum`, runtime namespace, parameter properties, decorators, JSX, or path aliases.
+- Relative imports include real `.ts` extensions.
+- Type-only imports use `import type`.
+- `tsc --noEmit` is allowed for type checking; it must not emit JavaScript artifacts.

--- a/specs/cli-ansi-renderer/design.md
+++ b/specs/cli-ansi-renderer/design.md
@@ -1,0 +1,294 @@
+# CLI ANSI Renderer — Design
+
+## Layer Assignment
+
+| Module or file                         | Package      | Layer                       | Purpose                                                      |
+| -------------------------------------- | ------------ | --------------------------- | ------------------------------------------------------------ |
+| `packages/cli/package.json`            | `@bruff/cli` | Package metadata            | Defines native Node TypeScript scripts and dependencies.     |
+| `packages/cli/tsconfig.json`           | `@bruff/cli` | Type-check config           | Enables erasable TypeScript syntax for direct Node runtime.  |
+| `packages/cli/eslint.config.js`        | `@bruff/cli` | Package-local lint config   | Reuses the workspace `@bruff/eslint-config` flat config.     |
+| `packages/cli/README.md`               | `@bruff/cli` | Package documentation       | Documents the mock-only scope and commands.                  |
+| `packages/cli/module/ansi.ts`          | `@bruff/cli` | Pure ANSI encoding          | Converts terminal commands into ANSI strings.                |
+| `packages/cli/module/terminal-cell.ts` | `@bruff/cli` | Pure render model           | Defines terminal cells, RGB colors, and frames.              |
+| `packages/cli/module/mock-scene.ts`    | `@bruff/cli` | Pure mock data              | Creates the deterministic sample frame using `@bruff/glyph`. |
+| `packages/cli/module/render-frame.ts`  | `@bruff/cli` | Pure frame projection       | Converts a terminal frame into ANSI commands and cleanup.    |
+| `packages/cli/module/write-frame.ts`   | `@bruff/cli` | Node writer boundary        | Writes encoded ANSI text to an injected stdout-like writer.  |
+| `packages/cli/index.ts`                | `@bruff/cli` | Public package API          | Exports pure renderer helpers and mock scene creation.       |
+| `packages/cli/bin/bruff-cli.ts`        | `@bruff/cli` | Executable Node entry point | Renders the mock scene and waits for a quit shortcut.        |
+| `packages/cli/**/*.test.ts`            | `@bruff/cli` | Native Node tests           | Uses `node:test` and `node:assert/strict` only.              |
+
+`@bruff/cli` is intentionally standalone at runtime. Its runtime and test source may import Node built-ins and `@bruff/glyph`; it must not import any other workspace package or any game package. Tooling files may import `@bruff/eslint-config` so lint behaviour stays aligned with the rest of the monorepo. The package does not own game abstractions yet.
+
+## Public API Surface
+
+```ts
+// packages/cli/module/terminal-cell.ts
+export type TerminalColor = Readonly<{
+  blue: number;
+  green: number;
+  red: number;
+}>;
+
+export type TerminalPosition = Readonly<{
+  column: number;
+  row: number;
+}>;
+
+export type TerminalCell = Readonly<{
+  backgroundColor: TerminalColor;
+  foregroundColor: TerminalColor;
+  glyph: string;
+  position: TerminalPosition;
+}>;
+
+export type TerminalFrame = Readonly<{
+  cells: ReadonlyArray<TerminalCell>;
+}>;
+```
+
+```ts
+// packages/cli/module/ansi.ts
+import type { TerminalColor, TerminalPosition } from "./terminal-cell.ts";
+
+export type AnsiCommand =
+  | { readonly type: "clear-screen" }
+  | { readonly type: "cursor-move"; readonly position: TerminalPosition }
+  | { readonly type: "reset-style" }
+  | { readonly color: TerminalColor; readonly type: "set-background" }
+  | { readonly color: TerminalColor; readonly type: "set-foreground" }
+  | { readonly glyph: string; readonly type: "write-glyph" };
+
+export const encodeAnsiCommand: (command: AnsiCommand) => string;
+export const encodeAnsiCommands: (
+  commands: ReadonlyArray<AnsiCommand>,
+) => string;
+```
+
+```ts
+// packages/cli/module/mock-scene.ts
+export const createMockTerminalFrame: () => TerminalFrame;
+```
+
+`createMockTerminalFrame()` imports glyph constants from `@bruff/glyph` and returns fixed mock cells such as a player marker, wall marker, treasure marker, and hazard marker. It does not import game state or package internals.
+
+```ts
+// packages/cli/module/render-frame.ts
+export const renderTerminalFrame: (
+  frame: TerminalFrame,
+) => ReadonlyArray<AnsiCommand>;
+```
+
+`renderTerminalFrame()` emits screen clearing, cursor movement, foreground color, background color, glyph write, a cursor move below the scene, and a final reset command for every frame.
+
+```ts
+// packages/cli/module/write-frame.ts
+export type TextWriter = Readonly<{
+  write: (text: string) => boolean;
+}>;
+
+export type WriteFrameResult =
+  | { readonly type: "ok" }
+  | { readonly reason: "write-failed" | "write-threw"; readonly type: "error" };
+
+export const writeTerminalFrame: (
+  writer: TextWriter,
+  frame: TerminalFrame,
+) => WriteFrameResult;
+```
+
+```ts
+// packages/cli/index.ts
+export { encodeAnsiCommand, encodeAnsiCommands } from "./module/ansi.ts";
+export { createMockTerminalFrame } from "./module/mock-scene.ts";
+export { renderTerminalFrame } from "./module/render-frame.ts";
+export { writeTerminalFrame } from "./module/write-frame.ts";
+export type { AnsiCommand } from "./module/ansi.ts";
+export type { TextWriter, WriteFrameResult } from "./module/write-frame.ts";
+export type {
+  TerminalCell,
+  TerminalColor,
+  TerminalFrame,
+  TerminalPosition,
+} from "./module/terminal-cell.ts";
+```
+
+The public API must stay package-local and game-free.
+
+```ts
+// packages/cli/bin/bruff-cli.ts
+import type { TextWriter, WriteFrameResult } from "../module/write-frame.ts";
+
+export type TextInputChunk = Buffer | string;
+
+export type TextInput = Readonly<{
+  isTTY?: boolean;
+  pause: () => TextInput;
+  resume: () => TextInput;
+  setRawMode?: (enabled: boolean) => TextInput;
+  on: (
+    eventName: "data",
+    listener: (chunk: TextInputChunk) => void,
+  ) => TextInput;
+  off: (
+    eventName: "data",
+    listener: (chunk: TextInputChunk) => void,
+  ) => TextInput;
+}>;
+
+export type BruffCliPorts = Readonly<{
+  input: TextInput;
+  writer: TextWriter;
+}>;
+
+export const runBruffCli: (ports: BruffCliPorts) => WriteFrameResult;
+```
+
+`runBruffCli()` renders the deterministic mock scene through an injected writer,
+then registers an injected input listener for `q`, `Q`, and `Ctrl+C`. If the
+input is a TTY with `setRawMode`, the CLI enables raw mode while waiting and
+restores it before pausing input on quit. If writing fails, it returns the write
+error without registering input. When `bin/bruff-cli.ts` is executed directly by
+Node, it wraps `process.stdin` and `process.stdout` in these ports and sets
+`process.exitCode = 1` if writing fails.
+
+## Data Flow
+
+```text
+@bruff/glyph constants
+  |
+  v
+mock-scene.ts
+  |
+  | TerminalFrame
+  v
+render-frame.ts
+  |
+  | ReadonlyArray<AnsiCommand>
+  v
+ansi.ts
+  |
+  | ANSI string
+  v
+write-frame.ts
+  |
+  | writer.write(text)
+  v
+process.stdout in bin/bruff-cli.ts
+
+process.stdin in bin/bruff-cli.ts
+  |
+  | q, Q, or Ctrl+C
+  v
+remove input listener, restore raw mode, pause input
+```
+
+Tests can stop at any pure boundary. The executable entry point is a thin shell over `createMockTerminalFrame()`, `writeTerminalFrame(process.stdout, frame)`, and an injected `process.stdin` quit listener.
+
+## Data Shape Changes
+
+No `GameState` migration is required. No game action, render command, replay fixture, browser API, or canvas type changes are allowed.
+
+`@bruff/cli` introduces terminal-local ADTs for colors, positions, cells, frames, ANSI commands, writer results, injected text writers, injected text input, and CLI ports. These types do not flow into any game package.
+
+## Native Node TypeScript Setup
+
+`packages/cli/package.json` should use `"type": "module"` and run `.ts` files directly:
+
+```json
+{
+  "dependencies": {
+    "@bruff/glyph": "workspace:0.0.0"
+  },
+  "devDependencies": {
+    "@bruff/eslint-config": "workspace:0.0.0",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "prettier": "catalog:",
+    "typescript": "catalog:"
+  },
+  "scripts": {
+    "cli": "node bin/bruff-cli.ts",
+    "format": "prettier --write .",
+    "lint": "eslint",
+    "test": "node --test \"**/*.test.ts\"",
+    "typecheck": "tsc --noEmit"
+  }
+}
+```
+
+`packages/cli/tsconfig.json` should keep all TypeScript erasable at runtime:
+
+```json
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": true,
+    "target": "esnext",
+    "verbatimModuleSyntax": true
+  }
+}
+```
+
+Tests must import from `.ts` files with explicit extensions and use only `node:test` plus `node:assert/strict`.
+
+`packages/cli/eslint.config.js` should follow the existing flat-config pattern used by sibling packages:
+
+```js
+import bruffEslintConfig from "@bruff/eslint-config";
+
+export default [
+  {
+    ignores: ["coverage/**/*.*"],
+  },
+  ...bruffEslintConfig,
+];
+```
+
+## Reuse Map
+
+| Existing file                               | Reuse                                                                 |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| `packages/glyph/index.ts`                   | Source of characters for mock terminal cells.                         |
+| `packages/eslint-config/README.md`          | Shared flat ESLint config usage pattern for package lint setup.       |
+| `packages/eslint-config/eslint.config.js`   | Local package export consumed by `packages/cli/eslint.config.js`.     |
+| `package.json`                              | Confirms root Node version supports native TypeScript execution.      |
+| `pnpm-workspace.yaml`                       | Existing `packages/*` workspace glob already includes `packages/cli`. |
+| `.agents/skills/node-native-tests/SKILL.md` | Test runner and TypeScript runtime constraints.                       |
+
+No other workspace package is reused by runtime or test source code.
+
+## Tradeoffs
+
+### Package Boundary
+
+- **Chosen: standalone mock renderer importing only `@bruff/glyph`.** This satisfies the current need to prove terminal rendering without forcing premature game package API decisions.
+- **Alternative: add `@bruff/game/headless` now.** Rejected because this spec explicitly defers game integration to a later spec.
+- **Alternative: import deep files from `packages/game`.** Rejected because it violates package ownership and the mock-only scope.
+
+### Runtime TypeScript
+
+- **Chosen: run `.ts` files directly with Node's native TypeScript support.** This keeps the CLI simple and avoids runtime transpiler dependencies.
+- **Alternative: use `tsx` or `ts-node`.** Rejected because the package must not rely on external runtime transpilers.
+- **Alternative: compile TypeScript to JavaScript before running.** Rejected for this first CLI because emitted artifacts are unnecessary; `tsc --noEmit` is enough for type checking.
+
+### Test Runner
+
+- **Chosen: native `node:test` with `node:assert/strict`.** It matches the package's Node-only scope and avoids browser or bundler infrastructure.
+- **Alternative: Vitest.** Rejected because this package must demonstrate plain Node execution without a test transpiler.
+- **Alternative: Playwright.** Rejected because the renderer is not browser code and does not use DOM or canvas APIs.
+
+### ANSI Rendering Strategy
+
+- **Chosen: encode explicit ANSI commands from a terminal frame.** Tests can assert exact escape sequences while keeping command construction readable. The command stream clears the screen before drawing and moves the cursor below the scene before resetting styles so shell output remains clean.
+- **Alternative: concatenate ANSI strings inline in the mock scene.** Rejected because it makes color and cursor behaviour harder to test independently.
+- **Alternative: adopt a TUI framework.** Rejected because the current scope is a tiny renderer with no input, layout engine, or terminal session lifecycle.
+
+### Quit Shortcut Strategy
+
+- **Chosen: wait for `q`, `Q`, or `Ctrl+C` through an injected stdin-like port.** This keeps the CLI visibly open after rendering while preserving deterministic tests and avoiding a game loop.
+- **Alternative: exit immediately after drawing.** Rejected because the terminal scene disappears into the shell prompt flow too quickly and does not behave like an interactive CLI.
+- **Alternative: implement a full input loop or terminal session manager.** Rejected because this spike only needs a quit shortcut, not gameplay input, resize handling, alternate screen mode, or terminal capability negotiation.

--- a/specs/cli-ansi-renderer/spec.md
+++ b/specs/cli-ansi-renderer/spec.md
@@ -1,0 +1,94 @@
+# CLI ANSI Renderer
+
+## Goal
+
+Create a new workspace package at `packages/cli` named `@bruff/cli` that renders a small, deterministic mock scene to an ANSI-compatible terminal using plain Node.js and TypeScript. The first version is a terminal rendering spike only: it proves colored foregrounds, colored backgrounds, cursor positioning, glyph output, screen clearing, and a minimal quit shortcut without importing game state or game render commands. Runtime source may import only `@bruff/glyph` from the workspace for character selection; package tooling must reuse the local shared lint package `@bruff/eslint-config`.
+
+## User-visible behaviour
+
+- The repo contains a new workspace package called `@bruff/cli` in `packages/cli`.
+- Running the package's CLI command from an interactive terminal prints a mock text-cell scene to stdout.
+- The mock scene contains multiple glyph characters sourced from `@bruff/glyph`.
+- The mock scene uses at least three distinct foreground colors.
+- The mock scene uses at least two distinct background colors.
+- The renderer positions cells with ANSI cursor movement rather than relying only on newline layout.
+- The renderer clears the terminal before drawing the mock scene.
+- The renderer resets terminal styling after drawing so subsequent shell output is not colored.
+- The renderer moves the cursor below the mock scene before returning control to the shell.
+- The command waits after drawing the mock scene until the user presses `q`, `Q`, or `Ctrl+C`.
+- The command does not start a game loop.
+- The command can render to a fake writer and listen to fake input in tests without opening a real TTY.
+- The package source does not import `@bruff/game`, `@bruff/game-element`, `@bruff/arcade`, `@bruff/utils`, or package internals from any workspace package except `@bruff/glyph`.
+- The package lint config imports `@bruff/eslint-config` from the workspace instead of duplicating package-local lint rules.
+- The package runs TypeScript directly with native Node.js TypeScript support; no `tsx`, `ts-node`, Babel, Vite, Vitest, Jest, or Playwright runtime is used.
+- Package tests use `node:test` and `node:assert/strict` against public exports and pure rendering helpers.
+
+## Out of scope
+
+- Rendering actual `@bruff/game` state, render commands, replay data, fixtures, or snapshots.
+- Adding or changing any game-related package, including `packages/game`, `packages/game-element`, and `packages/arcade`.
+- Adding a `@bruff/game/headless` export.
+- Creating a playable terminal game loop.
+- Reading gameplay keyboard, mouse, resize, or continuous terminal input.
+- Entering alternate screen mode or mouse reporting mode.
+- Implementing terminal lifecycle cleanup or process signal handling beyond the minimal quit shortcut and raw-mode restoration.
+- Implementing terminal capability negotiation through `terminfo`.
+- Depending on a third-party TUI framework.
+- Emitting JavaScript build artifacts from TypeScript source.
+- Introducing external TypeScript runtime transpilers or compilers for execution.
+- Sharing CLI renderer types with game packages.
+
+## Open questions (resolved)
+
+- **Q: Should this spec integrate with `@bruff/game` now?**  
+  A: No. The first package renders mock data only. A later spec will upgrade the CLI renderer to consume game-owned data.
+
+- **Q: Which workspace package may `@bruff/cli` import?**  
+  A: Runtime and test source may import only `@bruff/glyph`, and only to choose characters for terminal cells. Tooling config may import `@bruff/eslint-config`.
+
+- **Q: Should `@bruff/cli` use shared utility types from `@bruff/utils`?**  
+  A: No. The package should use local types and Node built-ins for this first mock renderer.
+
+- **Q: Should the package use Vitest because other packages do?**  
+  A: No. Tests must use native Node.js test support with `node:test` and `node:assert/strict`.
+
+- **Q: Should TypeScript be compiled before execution?**  
+  A: No. Runtime execution uses Node's native TypeScript support. `tsc --noEmit` may still be used as a type-checking gate.
+
+- **Q: Should the renderer require a real interactive TTY?**  
+  A: No. The command writes ANSI text to stdout and listens for quit input when available. Tests must be able to inject a fake writer and fake input.
+
+- **Q: Should the command exit immediately after drawing?**  
+  A: No. The command should keep the process alive after drawing and exit only when the user presses `q`, `Q`, or `Ctrl+C`.
+
+- **Q: Should stdout non-TTY handling be implemented now?**  
+  A: No. The renderer may write ANSI text to any writable stdout-like target. Rich TTY detection belongs to a later terminal-session spec.
+
+## Edge cases
+
+- The mock scene has no cells.
+- A cell has the same foreground and background color.
+- Multiple adjacent cells share the same colors.
+- Multiple cells occupy different rows and columns.
+- A glyph from `@bruff/glyph` is a multi-byte Unicode character.
+- ANSI output must reset styles even after rendering the final cell.
+- ANSI output must clear the screen before drawing so it does not overwrite the command line.
+- ANSI output must leave the cursor below the rendered scene so the next shell prompt is clean.
+- A writer reports a failed write by returning `false`.
+- A writer throws while receiving output.
+- Writing fails before input listeners are registered.
+- Input runs in a TTY that supports raw mode.
+- Input runs without raw-mode support, such as piped input.
+- The user quits with `q`.
+- The user quits with `Q`.
+- The user quits with `Ctrl+C`.
+- The renderer is called more than once with the same mock scene.
+- Tests run without a browser, DOM, pseudo-terminal, or external TypeScript transpiler.
+
+## Verification
+
+- `pnpm --filter @bruff/cli run format` passed and left package files unchanged.
+- `pnpm --filter @bruff/cli run lint` passed with `@bruff/eslint-config`.
+- `pnpm --filter @bruff/cli run typecheck` passed with native Node TypeScript settings.
+- `pnpm --filter @bruff/cli run test` passed 20 native `node:test` tests covering ANSI encoding, mock scene composition, frame rendering, writer errors, injected CLI writer behaviour, and quit input lifecycle.
+- `printf q | CI=true pnpm --filter @bruff/cli run cli` wrote ANSI text containing screen clearing, cursor movement, truecolor foregrounds, truecolor backgrounds, glyphs from `@bruff/glyph`, a final prompt cursor move, and a final reset sequence before exiting from the quit shortcut.

--- a/specs/cli-ansi-renderer/tasks.md
+++ b/specs/cli-ansi-renderer/tasks.md
@@ -1,0 +1,23 @@
+# CLI ANSI Renderer — Tasks
+
+- [x] T1 — Add `packages/cli/package.json`, `packages/cli/tsconfig.json`, `packages/cli/eslint.config.js`, `packages/cli/README.md`, `packages/cli/index.ts`, and `packages/cli/module/.gitkeep`.
+- [x] T2 — Add native Node test scripts and type-check scripts in `packages/cli/package.json` and `packages/cli/tsconfig.json`.
+- [x] T3 — Add terminal model types in `packages/cli/module/terminal-cell.ts`.
+- [x] T4 — Add ANSI encoder tests in `packages/cli/module/ansi.test.ts` covering cursor movement, foreground color, background color, glyph writes, and style reset.
+- [x] T5 — Implement ANSI encoder types and functions in `packages/cli/module/ansi.ts`.
+- [x] T6 — Add mock scene tests in `packages/cli/module/mock-scene.test.ts` proving glyphs come from `@bruff/glyph` and the scene contains multiple foreground and background colors.
+- [x] T7 — Implement deterministic mock scene creation in `packages/cli/module/mock-scene.ts`.
+- [x] T8 — Add frame rendering tests in `packages/cli/module/render-frame.test.ts` covering cursor positioning, color commands, glyph commands, empty frames, and final reset.
+- [x] T9 — Implement frame-to-command rendering in `packages/cli/module/render-frame.ts`.
+- [x] T10 — Add writer boundary tests in `packages/cli/module/write-frame.test.ts` covering successful writes, `false` write results, and thrown writer errors.
+- [x] T11 — Implement writer boundary in `packages/cli/module/write-frame.ts`.
+- [x] T12 — Add executable entry tests in `packages/cli/bin/bruff-cli.test.ts` covering injected writer behaviour without spawning a terminal.
+- [x] T13 — Implement executable entry point in `packages/cli/bin/bruff-cli.ts` and package script metadata in `packages/cli/package.json`.
+- [x] T14 — Add `@bruff/eslint-config` as a workspace dev dependency and use it from `packages/cli/eslint.config.js`.
+- [x] T15 — Export public CLI renderer APIs from `packages/cli/index.ts`.
+- [x] T16 — Document mock-only CLI usage, native TypeScript constraints, and deferred game integration in `packages/cli/README.md`.
+- [x] T17 — Run `pnpm --filter @bruff/cli run format`, `pnpm --filter @bruff/cli run lint`, `pnpm --filter @bruff/cli run typecheck`, and `pnpm --filter @bruff/cli run test`, then record verification in `specs/cli-ansi-renderer/spec.md`.
+- [x] T18 — Add clear-screen ANSI encoding tests in `packages/cli/module/ansi.test.ts` and command support in `packages/cli/module/ansi.ts`.
+- [x] T19 — Add prompt-cleanup frame rendering tests in `packages/cli/module/render-frame.test.ts` and cursor cleanup commands in `packages/cli/module/render-frame.ts`.
+- [x] T20 — Add injected quit-input tests in `packages/cli/bin/bruff-cli.test.ts` and wait for `q`, `Q`, or `Ctrl+C` in `packages/cli/bin/bruff-cli.ts`.
+- [x] T21 — Run `pnpm --filter @bruff/cli run lint`, `pnpm --filter @bruff/cli run typecheck`, `pnpm --filter @bruff/cli run test`, and `printf q | CI=true pnpm --filter @bruff/cli run cli`, then update `specs/cli-ansi-renderer/spec.md`.


### PR DESCRIPTION
## Summary

Implements the `specs/cli-ansi-renderer` SDTE plan for a new local `@bruff/cli` package.

- Added a Node-native TypeScript CLI package with local `@bruff/eslint-config` wiring.
- Added a pure ANSI renderer model for terminal cells, glyph frames, ANSI command encoding, and frame-to-
  command projection.
- Added a mock terminal scene using glyphs from `@bruff/glyph`.
- Added an injected terminal frame writer that returns typed write results instead of throwing.
- Wired `pnpm --filter @bruff/cli run cli` to render the mock ANSI scene.
- Fixed terminal cleanliness by clearing the screen before drawing and moving the cursor below the
  rendered scene before resetting style.
- Changed the CLI to remain open after rendering and quit only on `q`, `Q`, or `Ctrl+C`, with raw mode
  restored on exit.
- Updated the spec files to reflect the implemented renderer, prompt cleanup, quit behavior, and
  verification gates.
- Updated architecture guidance with a new `@bruff/cli` workspace entry, package override rules, and
  README notes.