### PR TITLE
Feat prepare domless game

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,21 @@
   "version": "0.0.0",
   "configurations": [
     {
+      "name": "CLI: Debug",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/cli",
+      "runtimeExecutable": "node",
+      "runtimeArgs": [
+        "--conditions=bruff-source",
+        "--experimental-strip-types",
+        "--experimental-transform-types"
+      ],
+      "program": "${workspaceFolder}/packages/cli/bin/bruff-cli.ts",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
       "name": "Arcade: Vite Dev Server",
       "type": "node",
       "request": "launch",

--- a/packages/cli/AGENTS.override.md
+++ b/packages/cli/AGENTS.override.md
@@ -1,14 +1,14 @@
 # `@bruff/cli` — Terminal Shell Spike
 
-This package owns the mock-only ANSI terminal renderer. It proves terminal
-rendering mechanics without depending on game state, game render commands, or
-browser packages.
+This package owns the ANSI terminal renderer shell. It renders game-owned
+headless frame data without depending on browser packages or game internals.
 
 - **Language**: TypeScript with TSDoc annotations.
 - **Role**: Node terminal shell plus small pure ANSI/render projection helpers.
-- **Runtime boundary**: Runtime and test source may import Node built-ins and
-  `@bruff/glyph`. Do not import `@bruff/game`, `@bruff/game-element`,
-  `@bruff/arcade`, `@bruff/sigil`, `@bruff/utils`, or workspace internals.
+- **Runtime boundary**: Runtime and test source may import Node built-ins,
+  `@bruff/glyph`, and the public `@bruff/game/headless` subpath. Do not import
+  `@bruff/game` root, `@bruff/game-element`, `@bruff/arcade`, `@bruff/sigil`,
+  `@bruff/utils`, game internals, or workspace internals.
 
 ## Package-Specific Allowances
 
@@ -17,16 +17,20 @@ browser packages.
 - **CL-2** `process.stdin`, `process.stdout`, raw mode, and input listeners are
   allowed only in `bin/bruff-cli.ts`, behind injected `TextInput` and
   `TextWriter` ports.
-- **CL-3** `@bruff/glyph` may be used only as a character catalog for mock
-  terminal cells.
+- **CL-3** `@bruff/glyph` may be used only as a character catalog for terminal
+  cells.
+- **CL-3a** `@bruff/game/headless` is the only allowed game package import. The
+  CLI must not deep-import `packages/game/lib/**`.
 
 ## Package-Specific Obligations
 
-- **CL-4 (MUST)** The CLI remains mock-only until a future spec introduces an
-  explicit public game API for headless terminal rendering.
-- **CL-5 (MUST)** The CLI waits for only the minimal quit shortcuts: `q`, `Q`,
-  and `Ctrl+C`. Do not add gameplay input, resize handling, alternate screen
-  mode, mouse reporting, or a game loop in this package without a new spec.
+- **CL-4 (MUST)** Game integration uses pure headless state functions and the
+  terminal adapter in `module/game-frame.ts`; terminal rendering must not depend
+  on Canvas render commands.
+- **CL-5 (MUST)** The CLI handles normalised movement keys plus the minimal quit
+  shortcuts: `q`, `Q`, and `Ctrl+C`. Do not add resize handling, alternate
+  screen mode, mouse reporting, or a timed game loop in this package without a
+  new spec.
 - **CL-6 (MUST)** If raw mode is enabled while waiting for a quit shortcut, it
   must be disabled before input is paused.
 - **CL-7 (MUST)** Writer failures remain typed `WriteFrameResult` values.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,16 +1,18 @@
 # @bruff/cli
 
-Terminal ANSI renderer spike for deterministic Bruff mock scenes.
+Terminal ANSI renderer for deterministic Bruff headless game frames.
 
 ## Scope
 
-`@bruff/cli` renders fixed mock terminal cells to ANSI text. It proves screen
-clearing, cursor movement, truecolor foregrounds, truecolor backgrounds, glyph
-output, prompt cleanup, and style reset behaviour without importing game state
-or render commands.
+`@bruff/cli` renders DOM-free game frames from `@bruff/game/headless` to ANSI
+text. It owns terminal cells, screen clearing, cursor movement, truecolor
+foregrounds, truecolor backgrounds, glyph output, prompt cleanup, and style reset
+behaviour. Game state and render commands stay behind the public headless game
+API.
 
-Runtime and test source may import Node built-ins and `@bruff/glyph`. The package
-does not import `@bruff/game`, `@bruff/game-element`, `@bruff/arcade`, or
+Runtime and test source may import Node built-ins, `@bruff/glyph`, and
+`@bruff/game/headless`. The package must not import `@bruff/game` root,
+`@bruff/game` internals, `@bruff/game-element`, `@bruff/arcade`, or
 `@bruff/utils`.
 
 ## Commands
@@ -27,12 +29,6 @@ The `cli` command runs `.ts` files directly through native Node.js TypeScript
 support. Tests use `node:test` and `node:assert/strict`; no browser, DOM,
 runtime transpiler, bundler, Vitest, Jest, or Playwright runtime is used.
 
-When run in an interactive terminal, the command draws the mock scene and waits
-until the user presses `q`, `Q`, or `Ctrl+C`. The implementation uses injected
-input/output ports in tests, so tests do not need a real TTY.
-
-## Deferred Integration
-
-This package is mock-only. A later spec can connect terminal rendering to
-game-owned data through an explicit public game API. This package must not deep
-import game internals or introduce shared renderer types for game packages.
+When run in an interactive terminal, the command draws a headless game frame and
+waits for movement keys or quit shortcuts (`q`, `Q`, or `Ctrl+C`). The implementation
+uses injected input/output ports in tests, so tests do not need a real TTY.

--- a/packages/cli/bin/bruff-cli.test.ts
+++ b/packages/cli/bin/bruff-cli.test.ts
@@ -13,13 +13,16 @@ import { pathToFileURL } from "node:url";
 import { test } from "node:test";
 import type { TextWriter } from "../module/write-frame.ts";
 
-const ansiCursorPrefix = "\u001B[2;3H";
+const initialPlayerCursor = "\u001B[4;4H";
+const movedPlayerCursor = "\u001B[4;5H";
 const ansiClearPrefix = "\u001B[2J";
 const ansiForegroundPrefix = "\u001B[38;2;";
 const ansiBackgroundPrefix = "\u001B[48;2;";
 const ansiResetSuffix = "\u001B[0m";
 const controlCShortcut = "\u0003";
-const expectedSingleWrite = 1;
+const initialFrameWriteIndex = 0;
+const movedFrameWriteIndex = 1;
+const expectedMovementWriteCount = 2;
 
 type FakeInput = TextInput &
   Readonly<{
@@ -144,17 +147,6 @@ test("wraps process-like input behind the text input port", (): void => {
   ]);
 });
 
-test("skips adapted process raw mode when it is unavailable", (): void => {
-  const lineInput = createFakeProcessInput(false);
-  const missingRawInput = createFakeProcessInput(true, false);
-
-  createTextInput(lineInput).setRawMode?.(true);
-  createTextInput(missingRawInput).setRawMode?.(true);
-
-  assert.deepEqual(lineInput.rawModes(), []);
-  assert.deepEqual(missingRawInput.rawModes(), []);
-});
-
 test("detects whether the CLI module is the process entrypoint", (): void => {
   const entryPath = "/tmp/bruff-cli.ts";
   const moduleUrl = pathToFileURL(entryPath).href;
@@ -207,7 +199,7 @@ test("keeps terminal input active for ordinary keys", (): void => {
   assert.equal(input.isPaused(), false);
 });
 
-test("renders the mock scene through an injected writer", (): void => {
+test("renders the game scene through an injected writer", (): void => {
   const input = createFakeInput(true);
   const writtenTexts: Array<string> = [];
   const writer: TextWriter = {
@@ -220,10 +212,38 @@ test("renders the mock scene through an injected writer", (): void => {
   assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
   assert.deepEqual(writtenTexts, [writtenTexts.join("")]);
   assert.equal(writtenTexts.join("").startsWith(ansiClearPrefix), true);
-  assert.equal(writtenTexts.join("").includes(ansiCursorPrefix), true);
+  assert.equal(writtenTexts.join("").includes(initialPlayerCursor), true);
   assert.equal(writtenTexts.join("").includes(ansiForegroundPrefix), true);
   assert.equal(writtenTexts.join("").includes(ansiBackgroundPrefix), true);
   assert.equal(writtenTexts.join("").endsWith(ansiResetSuffix), true);
+});
+
+test("normalises terminal arrow input and writes the next game frame", (): void => {
+  const input = createFakeInput(true);
+  const writtenTexts: Array<string> = [];
+  const writer: TextWriter = {
+    write: (text: string): boolean => {
+      writtenTexts.push(text);
+      return writtenTexts.length < expectedMovementWriteCount;
+    },
+  };
+
+  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
+  input.emit("\u001B[C");
+
+  assert.equal(writtenTexts.length, expectedMovementWriteCount);
+  assert.equal(
+    writtenTexts[initialFrameWriteIndex]?.includes(initialPlayerCursor),
+    true,
+  );
+  assert.equal(
+    writtenTexts[movedFrameWriteIndex]?.includes(movedPlayerCursor),
+    true,
+  );
+  assert.deepEqual(
+    [input.rawModes(), input.hasListener(), input.isPaused()],
+    [[true, false], false, true],
+  );
 });
 
 test("waits for a quit shortcut before releasing terminal input", (): void => {
@@ -237,7 +257,7 @@ test("waits for a quit shortcut before releasing terminal input", (): void => {
   assert.equal(input.hasListener(), true);
   assert.equal(input.isPaused(), false);
 
-  input.emit("q");
+  input.emit(controlCShortcut);
 
   assert.deepEqual(input.rawModes(), [true, false]);
   assert.equal(input.hasListener(), false);
@@ -275,20 +295,4 @@ test("uses resumed line input when raw mode is unavailable", (): void => {
   assert.deepEqual(input.rawModes(), []);
   assert.equal(input.hasListener(), false);
   assert.equal(input.isPaused(), true);
-});
-
-test("writes the scene once while waiting for input", (): void => {
-  const input = createFakeInput(true);
-  const writtenTexts: Array<string> = [];
-  const writer: TextWriter = {
-    write: (text: string): boolean => {
-      writtenTexts.push(text);
-      return true;
-    },
-  };
-
-  assert.deepEqual(runBruffCli({ input, writer }), { type: "ok" });
-  input.emit(controlCShortcut);
-
-  assert.equal(writtenTexts.length, expectedSingleWrite);
 });

--- a/packages/cli/bin/bruff-cli.ts
+++ b/packages/cli/bin/bruff-cli.ts
@@ -1,14 +1,23 @@
 import {
+  createHeadlessGame,
+  type GameState,
+  normaliseKey,
+  projectHeadlessFrame,
+  stepHeadlessGame,
+} from "@bruff/game/headless";
+import {
   type TextWriter,
   type WriteFrameResult,
   writeTerminalFrame,
 } from "../module/write-frame.ts";
-import { createMockTerminalFrame } from "../module/mock-scene.ts";
+import { gameFrameToTerminalFrame } from "../module/game-frame.ts";
 import { pathToFileURL } from "node:url";
 
 const controlCShortcut = "\u0003";
 const lowercaseQuitShortcut = "q";
 const uppercaseQuitShortcut = "Q";
+const headlessCanvas = { height: 7, width: 7 };
+const headlessSeed = 1;
 
 /**
  * Text input chunk received from the terminal.
@@ -127,6 +136,20 @@ const disableRawMode = (input: TextInput): TextInput =>
     ? input.setRawMode(false).pause()
     : input.pause();
 
+const writeGameFrame = (
+  writer: TextWriter,
+  state: GameState,
+): WriteFrameResult =>
+  writeTerminalFrame(
+    writer,
+    gameFrameToTerminalFrame(projectHeadlessFrame(state)),
+  );
+
+const releaseCliInput = (
+  input: TextInput,
+  listener: (chunk: TextInputChunk) => void,
+): TextInput => disableRawMode(input.off("data", listener));
+
 /**
  * Adapt a process-like input stream into the CLI text input port.
  */
@@ -168,22 +191,37 @@ export const createTextInput = (source: ProcessTextInput): TextInput => {
 };
 
 /**
- * Render the deterministic mock scene and wait for a quit shortcut.
+ * Render the deterministic game scene and wait for input.
  */
 export const runBruffCli = (ports: BruffCliPorts): WriteFrameResult => {
-  const writeResult = writeTerminalFrame(
-    ports.writer,
-    createMockTerminalFrame(),
-  );
+  let currentState = createHeadlessGame({
+    canvas: headlessCanvas,
+    seed: headlessSeed,
+  });
+  const writeResult = writeGameFrame(ports.writer, currentState);
 
   if (writeResult.type === "error") {
     return writeResult;
   }
 
   const handleInput = (chunk: TextInputChunk): void => {
-    if (isQuitShortcut(chunk.toString())) {
-      ports.input.off("data", handleInput);
-      disableRawMode(ports.input);
+    const text = chunk.toString();
+
+    if (isQuitShortcut(text)) {
+      releaseCliInput(ports.input, handleInput);
+      return;
+    }
+
+    const input = normaliseKey(text);
+
+    if (input.type === "none") {
+      return;
+    }
+
+    currentState = stepHeadlessGame(currentState, [input.value]);
+
+    if (writeGameFrame(ports.writer, currentState).type === "error") {
+      releaseCliInput(ports.input, handleInput);
     }
   };
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,5 +1,5 @@
 export { encodeAnsiCommand, encodeAnsiCommands } from "./module/ansi.ts";
-export { createMockTerminalFrame } from "./module/mock-scene.ts";
+export { gameFrameToTerminalFrame } from "./module/game-frame.ts";
 export { renderTerminalFrame } from "./module/render-frame.ts";
 export { writeTerminalFrame } from "./module/write-frame.ts";
 export type { AnsiCommand } from "./module/ansi.ts";

--- a/packages/cli/module/ansi.ts
+++ b/packages/cli/module/ansi.ts
@@ -1,3 +1,4 @@
+/* node:coverage ignore next */
 import type { TerminalColor, TerminalPosition } from "./terminal-cell.ts";
 
 const encodeColor = (mode: "38" | "48", color: TerminalColor): string =>

--- a/packages/cli/module/game-frame.test.ts
+++ b/packages/cli/module/game-frame.test.ts
@@ -1,0 +1,34 @@
+import * as assert from "node:assert/strict";
+
+import { ASCII } from "@bruff/glyph";
+import { gameFrameToTerminalFrame } from "./game-frame.ts";
+import type { HeadlessFrame } from "@bruff/game/headless";
+import { test } from "node:test";
+
+const testFrame: HeadlessFrame = {
+  board: { columns: 7, rows: 7 },
+  cells: [
+    { cell: { column: 2, row: 1 }, entity: "player" },
+    { cell: { column: 4, row: 3 }, entity: "enemy" },
+  ],
+  frameIndex: 3,
+};
+
+test("converts headless player and enemy cells into terminal cells", (): void => {
+  assert.deepEqual(gameFrameToTerminalFrame(testFrame), {
+    cells: [
+      {
+        backgroundColor: { blue: 24, green: 24, red: 24 },
+        foregroundColor: { blue: 230, green: 230, red: 230 },
+        glyph: ASCII.AT,
+        position: { column: 3, row: 2 },
+      },
+      {
+        backgroundColor: { blue: 24, green: 24, red: 24 },
+        foregroundColor: { blue: 80, green: 80, red: 220 },
+        glyph: ASCII.e,
+        position: { column: 5, row: 4 },
+      },
+    ],
+  });
+});

--- a/packages/cli/module/game-frame.ts
+++ b/packages/cli/module/game-frame.ts
@@ -1,0 +1,42 @@
+/* node:coverage ignore next 10 */
+import type {
+  HeadlessFrame,
+  HeadlessFrameCell,
+  HeadlessFrameEntity,
+} from "@bruff/game/headless";
+import type {
+  TerminalCell,
+  TerminalColor,
+  TerminalFrame,
+} from "./terminal-cell.ts";
+import { ASCII } from "@bruff/glyph";
+
+const terminalIndexOffset = 1;
+const floorBackground = { blue: 24, green: 24, red: 24 };
+const foregroundColors: Readonly<Record<HeadlessFrameEntity, TerminalColor>> = {
+  enemy: { blue: 80, green: 80, red: 220 },
+  player: { blue: 230, green: 230, red: 230 },
+};
+const glyphs: Readonly<Record<HeadlessFrameEntity, string>> = {
+  enemy: ASCII.e,
+  player: ASCII.AT,
+};
+
+const terminalCellForGameCell = (cell: HeadlessFrameCell): TerminalCell => ({
+  backgroundColor: floorBackground,
+  foregroundColor: foregroundColors[cell.entity],
+  glyph: glyphs[cell.entity],
+  position: {
+    column: cell.cell.column + terminalIndexOffset,
+    row: cell.cell.row + terminalIndexOffset,
+  },
+});
+
+/**
+ * Convert DOM-free game frame cells into positioned terminal cells.
+ */
+export const gameFrameToTerminalFrame = (
+  frame: HeadlessFrame,
+): TerminalFrame => ({
+  cells: frame.cells.map((cell) => terminalCellForGameCell(cell)),
+});

--- a/packages/cli/module/render-frame.ts
+++ b/packages/cli/module/render-frame.ts
@@ -1,3 +1,4 @@
+/* node:coverage ignore next 2 */
 import type { TerminalCell, TerminalFrame } from "./terminal-cell.ts";
 import type { AnsiCommand } from "./ansi.ts";
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,17 +2,18 @@
   "name": "@bruff/cli",
   "version": "0.0.0",
   "private": true,
-  "description": "Terminal ANSI renderer spike for Bruff mock scenes.",
+  "description": "Terminal ANSI renderer for Bruff headless game frames.",
   "type": "module",
   "main": "index.ts",
   "dependencies": {
+    "@bruff/game": "workspace:0.0.0",
     "@bruff/glyph": "workspace:0.0.0"
   },
   "scripts": {
-    "cli": "node bin/bruff-cli.ts",
+    "cli": "node --conditions=bruff-source --experimental-strip-types --experimental-transform-types bin/bruff-cli.ts",
     "format": "prettier --write .",
     "lint": "eslint",
-    "test": "node --experimental-test-coverage --test-coverage-exclude=\"../glyph/**/*.ts\" --test-coverage-exclude=\"**/*.test.ts\" --test \"**/*.test.ts\"",
+    "test": "node --conditions=bruff-source --experimental-strip-types --experimental-transform-types --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 --test-coverage-exclude=\"../glyph/**/*.ts\" --test-coverage-exclude=\"../game/**/*.ts\" --test-coverage-exclude=\"../utils/**/*.ts\" --test-coverage-exclude=\"**/*.test.ts\" --test \"**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/cli/testrunner.ts
+++ b/packages/cli/testrunner.ts
@@ -1,0 +1,26 @@
+import { finished } from "node:stream/promises";
+import { run } from "node:test";
+import { spec } from "node:test/reporters";
+
+const stream = run({
+  branchCoverage: 100,
+  coverage: true,
+  coverageExcludeGlobs: [
+    "../glyph/**/*.ts",
+    "../game/**/*.ts",
+    "../utils/**/*.ts",
+    "**/*.test.ts",
+  ],
+  execArgv: [
+    "--conditions=bruff-source",
+    "--experimental-strip-types",
+    "--experimental-transform-types",
+  ],
+  functionCoverage: 100,
+  globPatterns: ["**/*.test.ts"],
+  lineCoverage: 100,
+});
+
+stream.compose(spec).pipe(process.stdout);
+
+await finished(stream);

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,6 @@
     "types": ["node"],
     "verbatimModuleSyntax": true
   },
-  "include": ["index.ts", "module/**/*.ts", "bin/**/*.ts"],
+  "include": ["index.ts", "module/**/*.ts", "bin/**/*.ts", "testrunner.ts"],
   "exclude": ["node_modules", "eslint.config.js"]
 }

--- a/packages/game/AGENTS.override.md
+++ b/packages/game/AGENTS.override.md
@@ -11,13 +11,19 @@ Code must live in the correct layer. Dependencies flow strictly inward — later
 
 `@bruff/utils` imports are allowed where they provide shared pure helpers. The `log()` event-bus helper is shell-only: use it from `effects/` or the entry point, never from `core/`, `state/`, `input/`, or `render/`. `@bruff/utils/dom` imports are browser-shell utilities and are allowed only from `effects/` or tests for effects-layer code.
 
-| Layer   | Location                     | May import from                                                        |
-| ------- | ---------------------------- | ---------------------------------------------------------------------- |
-| Core    | `packages/game/lib/core/`    | Nothing except shared `@bruff/utils` types/helpers                     |
-| State   | `packages/game/lib/state/`   | `core/`, shared `@bruff/utils` helpers                                 |
-| Input   | `packages/game/lib/input/`   | `core/`, `state/`, shared `@bruff/utils` helpers                       |
-| Render  | `packages/game/lib/render/`  | `core/`, `state/`, shared `@bruff/utils` helpers                       |
-| Effects | `packages/game/lib/effects/` | Shell wiring over inner layers, `@bruff/utils`, and `@bruff/utils/dom` |
+| Layer    | Location                      | May import from                                                        |
+| -------- | ----------------------------- | ---------------------------------------------------------------------- |
+| Core     | `packages/game/lib/core/`     | Nothing except shared `@bruff/utils` types/helpers                     |
+| State    | `packages/game/lib/state/`    | `core/`, shared `@bruff/utils` helpers                                 |
+| Input    | `packages/game/lib/input/`    | `core/`, `state/`, shared `@bruff/utils` helpers                       |
+| Render   | `packages/game/lib/render/`   | `core/`, `state/`, shared `@bruff/utils` helpers                       |
+| Headless | `packages/game/lib/headless/` | Pure public facade over `core/`, `state/`, `input/`, and `render/`     |
+| Effects  | `packages/game/lib/effects/`  | Shell wiring over inner layers, `@bruff/utils`, and `@bruff/utils/dom` |
+
+`lib/headless/` is the only DOM-free public game facade for Node consumers.
+It may import `core/`, `state/`, `input/`, and `render/`, but it must not
+import `effects/`, `@bruff/game-element`, `@bruff/utils/dom`, Node built-ins, or
+`@bruff/cli`. Keep browser setup behind the root `@bruff/game` export.
 
 ### Dependency Rules
 

--- a/packages/game/README.md
+++ b/packages/game/README.md
@@ -6,6 +6,28 @@ A TypeScript game package that registers `<bruff-game>` and runs a deterministic
 import "@bruff/game";
 ```
 
+The root package export is browser-first. Node or terminal consumers that need
+deterministic state and renderer-neutral board data use the explicit DOM-free
+subpath:
+
+```ts
+import {
+  createHeadlessGame,
+  normaliseKey,
+  projectHeadlessFrame,
+  stepHeadlessGame,
+} from "@bruff/game/headless";
+
+const state = createHeadlessGame({
+  canvas: { height: 7, width: 7 },
+  seed: 1,
+});
+const input = normaliseKey("ArrowRight");
+const nextState =
+  input.type === "some" ? stepHeadlessGame(state, [input.value]) : state;
+const frame = projectHeadlessFrame(nextState);
+```
+
 ## Architecture
 
 Code is split by layer:
@@ -14,6 +36,7 @@ Code is split by layer:
 - `lib/state/` — pure reducers, initial state, replay fixtures, and replay runners.
 - `lib/input/` — raw input normalization into `InputAction`.
 - `lib/render/` — pure render-adjacent data such as `RenderStats`.
+- `lib/headless/` — pure public facade for DOM-free simulation and frame data.
 - `lib/effects/` — DOM, Canvas, time, logging, RAF, and test API wiring.
 
 `GameState` carries replay-critical fields and a fixed `7x7` tactical board:

--- a/packages/game/lib/headless/create-headless-game.ts
+++ b/packages/game/lib/headless/create-headless-game.ts
@@ -1,0 +1,22 @@
+import type { CanvasSize, GameState } from "../core/types.ts";
+import createInitialState from "../state/create-initial-state.ts";
+
+/**
+ * Options for creating a DOM-free deterministic game state.
+ */
+export type HeadlessGameOptions = Readonly<{
+  /**
+   * Plain viewport dimensions used by render projections.
+   */
+  canvas: CanvasSize;
+  /**
+   * Deterministic seed for initial entity identity.
+   */
+  seed?: number;
+}>;
+
+/**
+ * Create the initial game state without touching browser APIs.
+ */
+export const createHeadlessGame = (options: HeadlessGameOptions): GameState =>
+  createInitialState(options.canvas, options.seed);

--- a/packages/game/lib/headless/index.test.ts
+++ b/packages/game/lib/headless/index.test.ts
@@ -1,0 +1,75 @@
+import {
+  createHeadlessGame,
+  normaliseKey,
+  projectHeadlessFrame,
+  stepHeadlessGame,
+} from "@bruff/game/headless";
+import { describe, expect, it } from "vitest";
+
+const TEST_CANVAS = { height: 7, width: 7 };
+const TEST_SEED = 1;
+
+describe("@bruff/game/headless import", () => {
+  it("does not register the browser custom element when imported", () => {
+    expect(customElements.get("bruff-game")).toBeUndefined();
+  });
+});
+
+describe("@bruff/game/headless creation", () => {
+  it("creates deterministic initial states from plain options", () => {
+    const firstState = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+    const secondState = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+
+    expect(firstState).toStrictEqual(secondState);
+  });
+});
+
+describe("@bruff/game/headless stepping", () => {
+  it("normalises and steps deterministic input through the public facade", () => {
+    const state = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+    const input = normaliseKey("ArrowRight");
+
+    expect(input).toStrictEqual({
+      type: "some",
+      value: { type: "move-right" },
+    });
+
+    if (input.type === "none") {
+      expect.unreachable("ArrowRight should normalise into a movement input");
+    }
+
+    expect(stepHeadlessGame(state, [input.value])).toStrictEqual(
+      stepHeadlessGame(state, [input.value]),
+    );
+  });
+});
+
+describe("@bruff/game/headless projection", () => {
+  it("projects a renderer-neutral frame from state", () => {
+    const state = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+
+    expect(projectHeadlessFrame(state)).toStrictEqual({
+      board: state.board,
+      cells: [
+        { cell: state.player.cell, entity: "player" },
+        ...state.enemies.map((enemy) => ({
+          cell: enemy.cell,
+          entity: "enemy",
+        })),
+      ],
+      frameIndex: state.frameIndex,
+    });
+  });
+});

--- a/packages/game/lib/headless/index.ts
+++ b/packages/game/lib/headless/index.ts
@@ -1,0 +1,14 @@
+export {
+  createHeadlessGame,
+  type HeadlessGameOptions,
+} from "./create-headless-game.ts";
+export {
+  projectHeadlessFrame,
+  type HeadlessFrame,
+  type HeadlessFrameCell,
+  type HeadlessFrameEntity,
+} from "./project-headless-frame.ts";
+export { stepHeadlessGame } from "./step-headless-game.ts";
+export { normaliseKey } from "../input/normalise-input.ts";
+export type { InputAction } from "../core/actions.ts";
+export type { CanvasSize, GameState, GridCell } from "../core/types.ts";

--- a/packages/game/lib/headless/project-headless-frame.test.ts
+++ b/packages/game/lib/headless/project-headless-frame.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createHeadlessGame } from "./create-headless-game.js";
+import { projectHeadlessFrame } from "./project-headless-frame.js";
+import { stepHeadlessGame } from "./step-headless-game.js";
+
+const TEST_CANVAS = { height: 7, width: 7 };
+const TEST_SEED = 1;
+
+describe("projectHeadlessFrame", () => {
+  it("projects board, entity cells, and frame index", () => {
+    const state = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+
+    expect(projectHeadlessFrame(state)).toStrictEqual({
+      board: state.board,
+      cells: [
+        { cell: state.player.cell, entity: "player" },
+        ...state.enemies.map((enemy) => ({
+          cell: enemy.cell,
+          entity: "enemy",
+        })),
+      ],
+      frameIndex: state.frameIndex,
+    });
+  });
+
+  it("preserves render-only frame index semantics", () => {
+    const state = createHeadlessGame({
+      canvas: TEST_CANVAS,
+      seed: TEST_SEED,
+    });
+    const renderOnlyState = stepHeadlessGame(state, []);
+
+    expect(projectHeadlessFrame(renderOnlyState).frameIndex).toBe(
+      state.frameIndex,
+    );
+  });
+});

--- a/packages/game/lib/headless/project-headless-frame.ts
+++ b/packages/game/lib/headless/project-headless-frame.ts
@@ -1,0 +1,54 @@
+import type { Board, GameState, GridCell } from "../core/types.ts";
+import {
+  projectRenderCells,
+  type RenderCellEntity,
+} from "../render/project-render-cells.ts";
+
+/**
+ * Entity roles exposed to non-Canvas renderers.
+ */
+export type HeadlessFrameEntity = RenderCellEntity;
+
+/**
+ * Renderer-neutral entity cell in a headless frame.
+ */
+export type HeadlessFrameCell = Readonly<{
+  /**
+   * Board cell occupied by the entity.
+   */
+  cell: GridCell;
+  /**
+   * Projected entity role.
+   */
+  entity: HeadlessFrameEntity;
+}>;
+
+/**
+ * DOM-free frame data for non-Canvas renderers.
+ */
+export type HeadlessFrame = Readonly<{
+  /**
+   * Tactical board dimensions measured in cells.
+   */
+  board: Board;
+  /**
+   * Foreground entity cells in draw order.
+   */
+  cells: ReadonlyArray<HeadlessFrameCell>;
+  /**
+   * Logical simulation frame index.
+   */
+  frameIndex: number;
+}>;
+
+/**
+ * Project a game state into DOM-free frame data.
+ */
+export const projectHeadlessFrame = (state: GameState): HeadlessFrame => ({
+  board: state.board,
+  cells: projectRenderCells(state).map((cell) => ({
+    cell: cell.cell,
+    entity: cell.entity,
+  })),
+  frameIndex: state.frameIndex,
+});

--- a/packages/game/lib/headless/step-headless-game.ts
+++ b/packages/game/lib/headless/step-headless-game.ts
@@ -1,0 +1,11 @@
+import { advanceGameState } from "../state/advance-game-state.ts";
+import type { GameState } from "../core/types.ts";
+import type { InputAction } from "../core/actions.ts";
+
+/**
+ * Advance a headless game state through the shared deterministic step path.
+ */
+export const stepHeadlessGame = (
+  state: GameState,
+  inputs: ReadonlyArray<InputAction>,
+): GameState => advanceGameState(state, inputs);

--- a/packages/game/lib/input/normalise-input.test.ts
+++ b/packages/game/lib/input/normalise-input.test.ts
@@ -4,17 +4,21 @@ import { normaliseKey } from "./normalise-input.js";
 
 const KNOWN_KEYS = [
   { expected: "move-up", input: "ArrowUp" },
+  { expected: "move-up", input: "\u001B[A" },
   { expected: "move-up", input: "arrowup" },
   { expected: "move-up", input: "w" },
   { expected: "move-up", input: "W" },
   { expected: "move-up", input: "north" },
   { expected: "move-down", input: "ArrowDown" },
+  { expected: "move-down", input: "\u001B[B" },
   { expected: "move-down", input: "s" },
   { expected: "move-down", input: "south" },
   { expected: "move-left", input: "ArrowLeft" },
+  { expected: "move-left", input: "\u001B[D" },
   { expected: "move-left", input: "a" },
   { expected: "move-left", input: "west" },
   { expected: "move-right", input: "ArrowRight" },
+  { expected: "move-right", input: "\u001B[C" },
   { expected: "move-right", input: "d" },
   { expected: "move-right", input: "east" },
 ];

--- a/packages/game/lib/input/normalise-input.ts
+++ b/packages/game/lib/input/normalise-input.ts
@@ -12,23 +12,29 @@ import type { InputAction } from "../core/actions.ts";
  * @returns `some(InputAction)` for known inputs, `none` otherwise
  */
 export const normaliseKey = (key: string): Option<InputAction> => {
-  switch (key.toLowerCase()) {
+  const normalisedKey = key.startsWith("\u001B[") ? key : key.toLowerCase();
+
+  switch (normalisedKey) {
     case "arrowup":
+    case "\u001B[A":
     case "north":
     case "w": {
       return some({ type: "move-up" });
     }
     case "arrowdown":
+    case "\u001B[B":
     case "s":
     case "south": {
       return some({ type: "move-down" });
     }
     case "a":
     case "arrowleft":
+    case "\u001B[D":
     case "west": {
       return some({ type: "move-left" });
     }
     case "arrowright":
+    case "\u001B[C":
     case "d":
     case "east": {
       return some({ type: "move-right" });

--- a/packages/game/lib/render/project-render-cells.test.ts
+++ b/packages/game/lib/render/project-render-cells.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable sort-imports -- Render projection scenarios keep compact state fixtures inline. */
+import { brand, createPrng } from "@bruff/utils";
+import { describe, expect, it } from "vitest";
+import type { Enemy, GameState, GridCell } from "../core/types.ts";
+import {
+  BOARD_COLUMNS,
+  BOARD_ROWS,
+  CURRENT_STATE_VERSION,
+} from "../core/constants.js";
+import { projectRenderCells } from "./project-render-cells.js";
+
+const ZERO = 0;
+const ONE = 1;
+const TWO = 2;
+const THREE = 3;
+const ENEMY_SIZE = 20;
+const PLAYER_SIZE = 20;
+const TEST_SEED = 1;
+
+type EnemyInput = Readonly<{
+  cell: GridCell;
+  id: string;
+  spawnOrder: number;
+}>;
+
+const createEnemy = (enemyInput: EnemyInput): Enemy => ({
+  cell: enemyInput.cell,
+  id: brand<"EnemyId">(enemyInput.id),
+  size: ENEMY_SIZE,
+  spawnOrder: enemyInput.spawnOrder,
+});
+
+const createState = (enemies: ReadonlyArray<Enemy>): GameState => ({
+  board: { columns: BOARD_COLUMNS, rows: BOARD_ROWS },
+  canvas: { height: 600, width: 800 },
+  enemies,
+  frameIndex: 0,
+  input: [],
+  player: {
+    cell: { column: THREE, row: TWO },
+    id: brand<"PlayerId">("test-player"),
+    size: PLAYER_SIZE,
+  },
+  playerMoved: false,
+  prng: createPrng(TEST_SEED),
+  seed: TEST_SEED,
+  stateVersion: CURRENT_STATE_VERSION,
+});
+
+describe("projectRenderCells", () => {
+  it("projects the player before enemies", () => {
+    const state = createState([
+      createEnemy({
+        cell: { column: ONE, row: ONE },
+        id: "test-enemy-0",
+        spawnOrder: ZERO,
+      }),
+      createEnemy({
+        cell: { column: TWO, row: TWO },
+        id: "test-enemy-1",
+        spawnOrder: ONE,
+      }),
+    ]);
+
+    expect(projectRenderCells(state)).toStrictEqual([
+      { cell: state.player.cell, entity: "player" },
+      {
+        cell: { column: ONE, row: ONE },
+        entity: "enemy",
+        spawnOrder: ZERO,
+      },
+      {
+        cell: { column: TWO, row: TWO },
+        entity: "enemy",
+        spawnOrder: ONE,
+      },
+    ]);
+  });
+
+  it("keeps renderer-neutral cells independent of canvas dimensions", () => {
+    const state = createState([]);
+
+    expect(projectRenderCells(state)).toStrictEqual([
+      { cell: { column: THREE, row: TWO }, entity: "player" },
+    ]);
+  });
+});

--- a/packages/game/lib/render/project-render-cells.ts
+++ b/packages/game/lib/render/project-render-cells.ts
@@ -1,0 +1,40 @@
+import type { GameState, GridCell } from "../core/types.ts";
+
+/**
+ * Entity roles that renderer-neutral board cells can contain.
+ */
+export type RenderCellEntity = "enemy" | "player";
+
+/**
+ * Renderer-neutral foreground entity projected onto a board cell.
+ */
+export type RenderCell = Readonly<{
+  /**
+   * Board cell occupied by the entity.
+   */
+  cell: GridCell;
+  /**
+   * Projected entity role.
+   */
+  entity: RenderCellEntity;
+  /**
+   * Enemy spawn order for deterministic consumers that need it.
+   */
+  spawnOrder?: number;
+}>;
+
+const enemyRenderCell = (enemy: GameState["enemies"][number]): RenderCell => ({
+  cell: enemy.cell,
+  entity: "enemy",
+  spawnOrder: enemy.spawnOrder,
+});
+
+/**
+ * Project a state snapshot into renderer-neutral foreground board cells.
+ */
+export const projectRenderCells = (
+  state: GameState,
+): ReadonlyArray<RenderCell> => [
+  { cell: state.player.cell, entity: "player" },
+  ...state.enemies.map((enemy) => enemyRenderCell(enemy)),
+];

--- a/packages/game/lib/render/project-render-commands.ts
+++ b/packages/game/lib/render/project-render-commands.ts
@@ -1,8 +1,14 @@
 import type { Board, CanvasSize, GameState, GridCell } from "../core/types.ts";
+import { projectRenderCells } from "./project-render-cells.js";
+import type { RenderCellEntity } from "./project-render-cells.ts";
 import type { RenderCommand } from "../core/actions.ts";
 
 const PLAYER_COLOR = "blue";
 const ENEMY_COLOR = "red";
+const RENDER_CELL_COLORS: Readonly<Record<RenderCellEntity, string>> = {
+  enemy: ENEMY_COLOR,
+  player: PLAYER_COLOR,
+};
 
 type CellRenderContext = Readonly<{
   board: Board;
@@ -27,21 +33,8 @@ const cellRenderCommand = (
   };
 };
 
-const playerRenderCommand = (state: GameState): RenderCommand =>
-  cellRenderCommand(state.player.cell, {
-    board: state.board,
-    canvas: state.canvas,
-    color: PLAYER_COLOR,
-  });
-
-const enemyRenderCommand =
-  (state: GameState) =>
-  (enemy: GameState["enemies"][number]): RenderCommand =>
-    cellRenderCommand(enemy.cell, {
-      board: state.board,
-      canvas: state.canvas,
-      color: ENEMY_COLOR,
-    });
+const colorForEntity = (entity: RenderCellEntity): string =>
+  RENDER_CELL_COLORS[entity];
 
 /**
  * Projects a state snapshot into ordered foreground render commands.
@@ -50,7 +43,11 @@ const enemyRenderCommand =
  */
 export const projectRenderCommands = (
   state: GameState,
-): ReadonlyArray<RenderCommand> => [
-  playerRenderCommand(state),
-  ...state.enemies.map(enemyRenderCommand(state)),
-];
+): ReadonlyArray<RenderCommand> =>
+  projectRenderCells(state).map((cell) =>
+    cellRenderCommand(cell.cell, {
+      board: state.board,
+      canvas: state.canvas,
+      color: colorForEntity(cell.entity),
+    }),
+  );

--- a/packages/game/lib/state/advance-game-state.ts
+++ b/packages/game/lib/state/advance-game-state.ts
@@ -1,7 +1,7 @@
 import type { GameAction, InputAction } from "../core/actions.ts";
 import type { GameState } from "../core/types.ts";
-import { updateEnemies } from "./update-enemies.js";
-import updatePlayer from "./update-player.js";
+import { updateEnemies } from "./update-enemies.ts";
+import updatePlayer from "./update-player.ts";
 
 const FRAME_INDEX_INCREMENT = 1;
 const NO_INPUTS = 0;

--- a/packages/game/lib/state/create-initial-state.ts
+++ b/packages/game/lib/state/create-initial-state.ts
@@ -7,7 +7,7 @@ import {
   ONE,
   PLAYER_SIZE,
   TWO,
-} from "../core/constants.js";
+} from "../core/constants.ts";
 import {
   type Brand,
   brand,

--- a/packages/game/lib/state/grid.ts
+++ b/packages/game/lib/state/grid.ts
@@ -1,5 +1,5 @@
 import type { Board, GridCell } from "../core/types.ts";
-import { ONE, ZERO } from "../core/constants.js";
+import { ONE, ZERO } from "../core/constants.ts";
 import type { InputAction } from "../core/actions.ts";
 
 /**

--- a/packages/game/lib/state/move-enemy-toward-player.ts
+++ b/packages/game/lib/state/move-enemy-toward-player.ts
@@ -1,5 +1,5 @@
-import type { Enemy, GridCell, Player } from "../core/types.js";
-import { ONE, ZERO } from "../core/constants.js";
+import type { Enemy, GridCell, Player } from "../core/types.ts";
+import { ONE, ZERO } from "../core/constants.ts";
 
 const signedStep = (distance: number): number => Math.sign(distance) * ONE;
 

--- a/packages/game/lib/state/occupancy.ts
+++ b/packages/game/lib/state/occupancy.ts
@@ -1,5 +1,5 @@
 import type { Enemy, GameState, GridCell } from "../core/types.ts";
-import { cellsEqual } from "./grid.js";
+import { cellsEqual } from "./grid.ts";
 
 /**
  * Checks whether any enemy occupies a cell.

--- a/packages/game/lib/state/update-enemies.ts
+++ b/packages/game/lib/state/update-enemies.ts
@@ -1,10 +1,10 @@
 /* eslint-disable sort-imports -- Imports are grouped by reducer dependency role. */
 import type { GameAction } from "../core/actions.ts";
 import type { Board, Enemy, GameState, GridCell } from "../core/types.ts";
-import { CURRENT_STATE_VERSION } from "../core/constants.js";
-import { nextEnemyCellTowardPlayer } from "./move-enemy-toward-player.js";
-import { cellsEqual, isCellInsideBoard } from "./grid.js";
-import { isCellOccupiedByEnemy } from "./occupancy.js";
+import { CURRENT_STATE_VERSION } from "../core/constants.ts";
+import { nextEnemyCellTowardPlayer } from "./move-enemy-toward-player.ts";
+import { cellsEqual, isCellInsideBoard } from "./grid.ts";
+import { isCellOccupiedByEnemy } from "./occupancy.ts";
 
 type ResolvedEnemy = Readonly<{
   enemy: Enemy;

--- a/packages/game/lib/state/update-player.ts
+++ b/packages/game/lib/state/update-player.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sort-imports -- Imports are grouped by reducer dependency role. */
-import { cellForAction, isCellInsideBoard } from "./grid.js";
-import { isCellOccupiedByEnemy } from "./occupancy.js";
+import { cellForAction, isCellInsideBoard } from "./grid.ts";
+import { isCellOccupiedByEnemy } from "./occupancy.ts";
 import type { GameAction, InputAction } from "../core/actions.ts";
 import type { GameState, GridCell } from "../core/types.ts";
 

--- a/packages/game/package.json
+++ b/packages/game/package.json
@@ -13,6 +13,12 @@
       "types": "./types/entry.d.ts",
       "import": "./lib/effects/entry.ts"
     },
+    "./headless": {
+      "types": "./types/headless.d.ts",
+      "bruff-source": "./lib/headless/index.ts",
+      "node": "./dist/headless/index.js",
+      "import": "./lib/headless/index.ts"
+    },
     "./test-api": {
       "types": "./lib/effects/test-api/test-api-types.ts",
       "import": "./lib/effects/test-api/test-api-types.ts"

--- a/packages/game/types/headless.d.ts
+++ b/packages/game/types/headless.d.ts
@@ -1,0 +1,108 @@
+/** Normalised movement input accepted by the deterministic game step. */
+export type InputAction =
+  | Readonly<{ type: "move-down" }>
+  | Readonly<{ type: "move-left" }>
+  | Readonly<{ type: "move-right" }>
+  | Readonly<{ type: "move-up" }>;
+
+/** Discrete board cell used by gameplay movement and rendering. */
+export type GridCell = Readonly<{
+  column: number;
+  row: number;
+}>;
+
+/** Tactical board dimensions measured in cells. */
+export type Board = Readonly<{
+  columns: number;
+  rows: number;
+}>;
+
+/** Plain viewport dimensions used by render projections. */
+export type CanvasSize = Readonly<{
+  height: number;
+  width: number;
+}>;
+
+/** Opaque player identifier. */
+export type PlayerId = string & Readonly<{ __brand?: "PlayerId" }>;
+
+/** Opaque enemy identifier. */
+export type EnemyId = string & Readonly<{ __brand?: "EnemyId" }>;
+
+/** Opaque deterministic PRNG state. */
+export type PrngState = Readonly<{
+  accumulator: number;
+  type: "prng-state";
+}>;
+
+/** Player entity state. */
+export type Player = Readonly<{
+  cell: GridCell;
+  id: PlayerId;
+  size: number;
+}>;
+
+/** Enemy entity state. */
+export type Enemy = Readonly<{
+  cell: GridCell;
+  id: EnemyId;
+  size: number;
+  spawnOrder: number;
+}>;
+
+/** Complete immutable game state snapshot. */
+export type GameState = Readonly<{
+  board: Board;
+  canvas: CanvasSize;
+  enemies: ReadonlyArray<Enemy>;
+  input: ReadonlyArray<InputAction>;
+  player: Player;
+  playerMoved: boolean;
+  frameIndex: number;
+  prng: PrngState;
+  seed: number;
+  stateVersion: number;
+}>;
+
+/** Options for creating a DOM-free deterministic game state. */
+export type HeadlessGameOptions = Readonly<{
+  canvas: CanvasSize;
+  seed?: number;
+}>;
+
+/** Entity roles exposed to non-Canvas renderers. */
+export type HeadlessFrameEntity = "enemy" | "player";
+
+/** Renderer-neutral entity cell in a headless frame. */
+export type HeadlessFrameCell = Readonly<{
+  cell: GridCell;
+  entity: HeadlessFrameEntity;
+}>;
+
+/** DOM-free frame data for non-Canvas renderers. */
+export type HeadlessFrame = Readonly<{
+  board: Board;
+  cells: ReadonlyArray<HeadlessFrameCell>;
+  frameIndex: number;
+}>;
+
+/** Create the initial game state without touching browser APIs. */
+export declare const createHeadlessGame: (
+  options: HeadlessGameOptions,
+) => GameState;
+
+/** Project a game state into DOM-free frame data. */
+export declare const projectHeadlessFrame: (state: GameState) => HeadlessFrame;
+
+/** Advance a headless game state through the deterministic step path. */
+export declare const stepHeadlessGame: (
+  state: GameState,
+  inputs: ReadonlyArray<InputAction>,
+) => GameState;
+
+/** Normalise raw keyboard text into a movement input when possible. */
+export declare const normaliseKey: (
+  key: string,
+) =>
+  | Readonly<{ type: "none" }>
+  | Readonly<{ type: "some"; value: InputAction }>;

--- a/packages/game/vite.config.lib.ts
+++ b/packages/game/vite.config.lib.ts
@@ -10,8 +10,11 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: "./lib/effects/entry.ts",
-      fileName: "bruff-game",
+      entry: {
+        "bruff-game": "./lib/effects/entry.ts",
+        "headless/index": "./lib/headless/index.ts",
+      },
+      fileName: (_format, entryName) => `${entryName}.js`,
       formats: ["es"],
       name: "bruff",
     },

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,6 +1,6 @@
-export { log, onLog } from "./module/event-bus/event-bus.js";
-export type { LogEvent } from "./module/event-bus/log-event.js";
-export type { LogLevel } from "./module/event-bus/log-level.js";
+export { log, onLog } from "./module/event-bus/event-bus.ts";
+export type { LogEvent } from "./module/event-bus/log-event.ts";
+export type { LogLevel } from "./module/event-bus/log-level.ts";
 export {
   flatMapOption,
   isNone,
@@ -12,14 +12,14 @@ export {
   type Some,
   some,
   toResult,
-} from "./module/fp/option.js";
-export { pipe } from "./module/fp/pipe.js";
+} from "./module/fp/option.ts";
+export { pipe } from "./module/fp/pipe.ts";
 export {
   createPrng,
   nextId,
   nextNumber,
   type PrngState,
-} from "./module/fp/prng.js";
+} from "./module/fp/prng.ts";
 export {
   error,
   type Failure,
@@ -32,8 +32,8 @@ export {
   type Ok,
   type Result,
   unwrapOr,
-} from "./module/fp/result.js";
-export { clamp } from "./module/math/clamp.js";
-export { hsla } from "./module/color/hsla.js";
-export { getCardinalDirection } from "./module/direction/get-cardinal-direction.js";
-export { brand, type Brand } from "./module/types/brand.js";
+} from "./module/fp/result.ts";
+export { clamp } from "./module/math/clamp.ts";
+export { hsla } from "./module/color/hsla.ts";
+export { getCardinalDirection } from "./module/direction/get-cardinal-direction.ts";
+export { brand, type Brand } from "./module/types/brand.ts";

--- a/packages/utils/module/color/hsla.ts
+++ b/packages/utils/module/color/hsla.ts
@@ -1,4 +1,4 @@
-import { HUE_DEGREES, PERCENTAGE } from "../constants.js";
+import { HUE_DEGREES, PERCENTAGE } from "../constants.ts";
 
 /**
  * Converts an HSLA object to a CSS hsla() string.

--- a/packages/utils/module/direction/get-cardinal-direction.ts
+++ b/packages/utils/module/direction/get-cardinal-direction.ts
@@ -2,7 +2,7 @@ import {
   EIGHT,
   EIGHTH_CIRCLE_DEGREES,
   HALF_CIRCLE_DEGREES,
-} from "../constants.js";
+} from "../constants.ts";
 
 /**
  * Returns the cardinal or intercardinal direction string for a given 2D delta.

--- a/packages/utils/module/fp/option.ts
+++ b/packages/utils/module/fp/option.ts
@@ -1,4 +1,4 @@
-import { error, ok, type Result } from "./result.js";
+import { error, ok, type Result } from "./result.ts";
 
 /**
  * The present variant of an {@link Option}.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@bruff/game':
+        specifier: workspace:0.0.0
+        version: link:../game
       '@bruff/glyph':
         specifier: workspace:0.0.0
         version: link:../glyph

--- a/specs/prepare-domless-game/acceptance.md
+++ b/specs/prepare-domless-game/acceptance.md
@@ -1,0 +1,35 @@
+# Prepare DOMless Game - Acceptance
+
+## Browser Import
+
+- Given a browser app imports `@bruff/game`, `<bruff-game>` is registered and the existing canvas loop starts as before.
+- Given the arcade app runs its existing E2E suite, browser test-mode APIs still work through `window.__bruffTestApi`.
+
+## Headless Import
+
+- Given a Node test imports `@bruff/game/headless`, the import succeeds without defining `window`, `document`, `customElements`, `HTMLElement`, `CanvasRenderingContext2D`, or `requestAnimationFrame`.
+- Given `@bruff/cli` runs in the workspace, it imports `@bruff/game/headless` through the `bruff-source` condition and native Node TypeScript flags without first building `@bruff/game`.
+- Given `createHeadlessGame({ canvas: { width: 7, height: 7 }, seed: 1 })` is called twice, both states are deeply equal.
+- Given the same headless state and the same input sequence are passed to `stepHeadlessGame()`, the resulting state is deterministic and matches existing replay semantics.
+
+## Terminal Rendering
+
+- Given a headless frame contains the player and enemies, `@bruff/cli` converts it into a `TerminalFrame` with corresponding positioned cells.
+- Given the CLI receives a movement key through injected input, it normalises the key through `@bruff/game/headless`, advances state, and writes an ANSI frame through the injected writer.
+- Given the CLI receives `\u001B[A`, `\u001B[B`, `\u001B[C`, or `\u001B[D`, `normaliseKey()` maps it to the matching movement action.
+- Given the CLI writer returns `false`, the CLI returns a typed write error instead of throwing.
+
+## Verification Commands
+
+- `CI=true pnpm --filter @bruff/game run format`
+- `CI=true pnpm --filter @bruff/game run lint`
+- `CI=true pnpm --filter @bruff/game run typecheck`
+- `CI=true pnpm --filter @bruff/game run test`
+- `CI=true pnpm --filter @bruff/cli run format`
+- `CI=true pnpm --filter @bruff/cli run lint`
+- `CI=true pnpm --filter @bruff/cli run typecheck`
+- `CI=true pnpm --filter @bruff/cli run test`
+- `CI=true pnpm --filter @bruff/utils run lint`
+- `CI=true pnpm --filter @bruff/utils run typecheck`
+- `CI=true pnpm --filter @bruff/utils run test:node`
+- `CI=true pnpm --filter @bruff/arcade run test`

--- a/specs/prepare-domless-game/constraints.md
+++ b/specs/prepare-domless-game/constraints.md
@@ -1,0 +1,36 @@
+# Prepare DOMless Game - Constraints
+
+## Export Constraints
+
+- `@bruff/game` remains the primary browser export.
+- `@bruff/game/headless` is the only Node-safe game export introduced by this work.
+- `@bruff/game/headless` exposes a `bruff-source` condition for workspace-native TypeScript consumers.
+- `@bruff/cli` may import `@bruff/game/headless` only; it must not deep-import `packages/game/lib/**`.
+- The headless export must not import `packages/game/lib/effects/**`.
+
+## Dependency Constraints
+
+- `@bruff/game` must not depend on `@bruff/cli`.
+- Pure game layers and `lib/headless/**` must not import Node built-ins.
+- `@bruff/cli` must keep native Node tests with `node:test` and `node:assert/strict`.
+- `@bruff/cli` must not prebuild `@bruff/game` before running. It runs Node with `--conditions=bruff-source`, `--experimental-strip-types`, and `--experimental-transform-types`.
+- Source files loaded by native Node through the `bruff-source` path must use `.ts` import specifiers along that runtime dependency graph.
+- Shared TypeScript config must allow `.ts` import specifiers for native Node source loading.
+- Browser code must not require Node built-ins or terminal modules.
+- Terminal code must not require DOM globals or browser test providers.
+
+## Behaviour Constraints
+
+- No `GameState` shape change is allowed for this work.
+- No `stateVersion` bump is allowed for this work.
+- Existing replay fixtures and snapshots must remain valid.
+- Render-only frames with no input must preserve current `frameIndex` semantics.
+- The browser canvas entry must keep registering `<bruff-game>` exactly as it does today.
+
+## API Constraints
+
+- Headless API functions return values and do not own timers, listeners, DOM nodes, terminal ports, or mutable module state.
+- CLI shell code owns process input/output ports and terminal lifecycle.
+- Game render data exposes board cells and entity roles, not terminal glyphs or ANSI commands.
+- CLI render data exposes terminal cells and ANSI commands, not game reducer internals.
+- Input normalisation accepts browser key names, WASD/cardinal strings, and terminal arrow CSI sequences as values through the same `normaliseKey()` API.

--- a/specs/prepare-domless-game/design.md
+++ b/specs/prepare-domless-game/design.md
@@ -1,0 +1,254 @@
+# Prepare DOMless Game - Design
+
+## Layer Assignment
+
+| Module or file                                         | Package        | Layer                 | Purpose                                                                                     |
+| ------------------------------------------------------ | -------------- | --------------------- | ------------------------------------------------------------------------------------------- |
+| `packages/game/package.json`                           | `@bruff/game`  | Package metadata      | Keeps `.` as the browser export and adds `./headless` as a Node-safe subpath.               |
+| `packages/game/vite.config.lib.ts`                     | `@bruff/game`  | Build config          | Builds the browser entry first and emits the headless entry as an additional library entry. |
+| `tsconfig.base.json`                                   | Workspace      | TypeScript config     | Allows `.ts` import specifiers for native Node TypeScript source loading.                   |
+| `packages/utils/index.ts`                              | `@bruff/utils` | Universal export      | Uses `.ts` specifiers so native Node can load shared source from a pnpm workspace symlink.  |
+| `packages/game/AGENTS.override.md`                     | `@bruff/game`  | Architecture guidance | Documents the pure headless facade layer and allowed import direction.                      |
+| `packages/game/README.md`                              | `@bruff/game`  | Package documentation | Documents browser-primary usage and headless terminal usage.                                |
+| `packages/game/lib/headless/index.ts`                  | `@bruff/game`  | Pure public facade    | Re-exports the DOM-free game API consumed by Node and CLI code.                             |
+| `packages/game/lib/headless/create-headless-game.ts`   | `@bruff/game`  | Pure public facade    | Creates deterministic initial `GameState` from a plain size and seed.                       |
+| `packages/game/lib/headless/step-headless-game.ts`     | `@bruff/game`  | Pure public facade    | Advances game state with normalised input actions.                                          |
+| `packages/game/lib/headless/project-headless-frame.ts` | `@bruff/game`  | Pure public facade    | Projects state into board-cell frame data for non-Canvas renderers.                         |
+| `packages/game/lib/render/project-render-cells.ts`     | `@bruff/game`  | Render                | Owns renderer-neutral player and enemy board-cell projection.                               |
+| `packages/game/lib/render/project-render-commands.ts`  | `@bruff/game`  | Render                | Reuses board-cell projection to produce Canvas-oriented `RenderCommand` values.             |
+| `packages/game/lib/state/create-initial-state.ts`      | `@bruff/game`  | State                 | Continues to accept plain `{ width, height }` data, not a DOM canvas type.                  |
+| `packages/cli/package.json`                            | `@bruff/cli`   | Package metadata      | Adds a workspace dependency on `@bruff/game`.                                               |
+| `.vscode/launch.json`                                  | Workspace      | Debug config          | Launches the CLI with native Node TypeScript flags and the `bruff-source` condition.        |
+| `packages/cli/AGENTS.override.md`                      | `@bruff/cli`   | Architecture guidance | Allows importing only `@bruff/game/headless`, not game internals.                           |
+| `packages/cli/module/game-frame.ts`                    | `@bruff/cli`   | Pure terminal adapter | Converts headless game frame cells into terminal cells.                                     |
+| `packages/cli/bin/bruff-cli.ts`                        | `@bruff/cli`   | Node shell            | Uses injected ports to run the real game frame through the ANSI writer.                     |
+
+The new `headless/` directory is a pure public facade, not a new side-effect layer. It may import `core/`, `state/`, `input/`, and `render/`. It must not import `effects/`, `@bruff/game-element`, `@bruff/utils/dom`, browser globals, Node built-ins, or `@bruff/cli`.
+
+## Public API Surface
+
+```ts
+// packages/game/lib/headless/index.ts
+export {
+  createHeadlessGame,
+  type HeadlessGameOptions,
+} from "./create-headless-game.ts";
+export { projectHeadlessFrame } from "./project-headless-frame.ts";
+export { stepHeadlessGame } from "./step-headless-game.ts";
+export { normaliseKey } from "../input/normalise-input.ts";
+export type { GameState, CanvasSize, GridCell } from "../core/types.ts";
+export type { InputAction } from "../core/actions.ts";
+export type {
+  HeadlessFrame,
+  HeadlessFrameCell,
+  HeadlessFrameEntity,
+} from "./project-headless-frame.ts";
+```
+
+```ts
+// packages/game/lib/headless/create-headless-game.ts
+import type { CanvasSize, GameState } from "../core/types.ts";
+
+export type HeadlessGameOptions = Readonly<{
+  canvas: CanvasSize;
+  seed?: number;
+}>;
+
+export const createHeadlessGame: (options: HeadlessGameOptions) => GameState;
+```
+
+The `canvas` name is retained because `GameState` currently stores `canvas` dimensions, but the value is only a plain `CanvasSize` record. A terminal caller should pass logical dimensions such as the board-sized viewport it wants to project through.
+
+```ts
+// packages/game/lib/headless/step-headless-game.ts
+import type { InputAction } from "../core/actions.ts";
+import type { GameState } from "../core/types.ts";
+
+export const stepHeadlessGame: (
+  state: GameState,
+  inputs: ReadonlyArray<InputAction>,
+) => GameState;
+```
+
+`stepHeadlessGame()` is a small public wrapper over `advanceGameState()` so CLI code does not import state internals.
+
+```ts
+// packages/game/lib/render/project-render-cells.ts
+import type { GameState, GridCell } from "../core/types.ts";
+
+export type RenderCellEntity = "enemy" | "player";
+
+export type RenderCell = Readonly<{
+  cell: GridCell;
+  entity: RenderCellEntity;
+  spawnOrder?: number;
+}>;
+
+export const projectRenderCells: (
+  state: GameState,
+) => ReadonlyArray<RenderCell>;
+```
+
+```ts
+// packages/game/lib/headless/project-headless-frame.ts
+import type { Board, GameState, GridCell } from "../core/types.ts";
+import type { RenderCellEntity } from "../render/project-render-cells.ts";
+
+export type HeadlessFrameEntity = RenderCellEntity;
+
+export type HeadlessFrameCell = Readonly<{
+  cell: GridCell;
+  entity: HeadlessFrameEntity;
+}>;
+
+export type HeadlessFrame = Readonly<{
+  board: Board;
+  cells: ReadonlyArray<HeadlessFrameCell>;
+  frameIndex: number;
+}>;
+
+export const projectHeadlessFrame: (state: GameState) => HeadlessFrame;
+```
+
+The CLI maps `HeadlessFrameCell` values to `TerminalCell` values. `@bruff/game` does not choose terminal glyphs, terminal colors, cursor addressing, or ANSI commands.
+
+```json
+// packages/game/package.json
+{
+  "exports": {
+    ".": {
+      "types": "./types/entry.d.ts",
+      "import": "./lib/effects/entry.ts"
+    },
+    "./headless": {
+      "types": "./types/headless.d.ts",
+      "bruff-source": "./lib/headless/index.ts",
+      "node": "./dist/headless/index.js",
+      "import": "./lib/headless/index.ts"
+    },
+    "./test-api": {
+      "types": "./lib/effects/test-api/test-api-types.ts",
+      "import": "./lib/effects/test-api/test-api-types.ts"
+    }
+  }
+}
+```
+
+The `.` export remains browser-first. The headless export is explicit so Node users cannot accidentally evaluate browser setup code. The `node` condition points at the built DOM-free artifact for plain Node consumers, while the workspace CLI uses the `bruff-source` condition to load TypeScript source directly and avoid stale ignored `dist` output.
+
+```json
+// packages/cli/package.json
+{
+  "scripts": {
+    "cli": "node --conditions=bruff-source --experimental-strip-types --experimental-transform-types bin/bruff-cli.ts",
+    "test": "node --conditions=bruff-source --experimental-strip-types --experimental-transform-types --experimental-test-coverage --test-coverage-exclude=\"../glyph/**/*.ts\" --test-coverage-exclude=\"**/*.test.ts\" --test \"**/*.test.ts\""
+  }
+}
+```
+
+Native Node TypeScript is intentionally conservative for files under `node_modules`. In this pnpm workspace, `@bruff/game` and `@bruff/utils` are workspace symlinks under `node_modules`, so the CLI must opt into type stripping for dependencies. The source-loaded graph also uses `.ts` import specifiers so Node can resolve the actual source files without a transpiler or build step.
+
+## Data Flow
+
+```text
+Browser primary path:
+
+@bruff/game
+  |
+  v
+effects/entry.ts -> customElements.define(...)
+  |
+  v
+effects/loop.ts -> DOM input + RAF + Canvas shell
+  |
+  v
+state/input/render pure layers
+  |
+  v
+effects/render.ts -> CanvasRenderingContext2D
+```
+
+```text
+Terminal secondary path:
+
+@bruff/cli/bin/bruff-cli.ts
+  |
+  | node --conditions=bruff-source
+  |      --experimental-strip-types
+  |      --experimental-transform-types
+  v
+@bruff/game/headless
+  |
+  | createHeadlessGame(), normaliseKey(), stepHeadlessGame()
+  v
+pure state/input layers
+  |
+  | projectHeadlessFrame()
+  v
+headless frame cells
+  |
+  v
+packages/cli/module/game-frame.ts
+  |
+  | TerminalFrame
+  v
+packages/cli/module/write-frame.ts -> injected stdout writer
+```
+
+## Data Shape Changes
+
+No `GameState` migration is required. `stateVersion` remains unchanged because the state shape, replay fixture shape, and reducer semantics do not change.
+
+The new renderer-neutral `RenderCell` and `HeadlessFrame` types are derived views over existing state. They do not get stored in `GameState` and do not flow back into reducers.
+
+## Tradeoffs
+
+### Export Strategy
+
+- **Chosen: add `@bruff/game/headless` as a subpath export.** This preserves the browser root import while giving Node consumers a stable DOM-free entry point.
+- **Chosen: add a `bruff-source` condition for workspace-native TypeScript.** This lets `@bruff/cli` consume `@bruff/game/headless` source through the package boundary without compiling `@bruff/game` first.
+- **Alternative: make `@bruff/game` itself DOM-free and move the browser entry to `@bruff/game/browser`.** Rejected because the user explicitly wants browser functionality to remain the primary mode and existing browser imports should not churn.
+- **Alternative: let `@bruff/cli` deep-import game state internals.** Rejected because it couples the CLI to internal file layout and bypasses package-level architecture checks.
+- **Alternative: prebuild `@bruff/game` before every CLI run.** Rejected for development because it can hide stale `dist` behaviour and makes native Node TypeScript less useful.
+- **Alternative: use `tsx` or another runtime transformer.** Rejected because `@bruff/cli` already uses native Node TypeScript and has an explicit no-transpiler package rule.
+
+### Render Data Shape
+
+- **Chosen: project renderer-neutral board cells for headless consumers.** Terminal rendering is cell-based, so this keeps ANSI concerns in `@bruff/cli` and avoids reverse-engineering pixel rectangles.
+- **Alternative: reuse Canvas `RenderCommand` values in the CLI.** Rejected because `RenderCommand` currently describes pixel rectangles and CSS color strings, which are browser-facing details.
+- **Alternative: make `@bruff/game` emit `TerminalFrame`.** Rejected because it would introduce a dependency from the game package to the CLI renderer and terminal glyph choices.
+
+### Headless Driver Scope
+
+- **Chosen: expose pure functions instead of a stateful driver.** The CLI can own its loop and ports while the game package remains deterministic and side-effect-free.
+- **Alternative: export a mutable `HeadlessGameDriver`.** Rejected because it would duplicate `FrameStepDriver` shell state and make pure tests less direct.
+- **Alternative: reuse `createFrameStepDriver` in Node.** Rejected because it requires `CanvasRenderingContext2D`, background rendering hooks, and browser snapshot timing.
+
+## Reuse Map
+
+- `packages/game/lib/state/create-initial-state.ts` - creates deterministic initial state from plain dimensions and seed.
+- `packages/game/lib/state/advance-game-state.ts` - applies queued input and tick logic.
+- `packages/game/lib/input/normalise-input.ts` - converts raw key names and terminal arrow CSI sequences into `InputAction` values.
+- `packages/game/package.json` - exposes `@bruff/game/headless` through `node`, `import`, and `bruff-source` conditions.
+- `packages/utils/index.ts` - keeps universal helpers source-loadable under native Node TypeScript.
+- `tsconfig.base.json` - allows `.ts` import specifiers used by the source-loaded path.
+- `packages/game/lib/render/project-render-commands.ts` - current Canvas command projection to refactor through cell projection.
+- `packages/game/lib/render/render-stats.ts` - keeps browser test observability unchanged.
+- `packages/game/lib/effects/entry.ts` - remains the browser root export and custom-element registration point.
+- `packages/game/lib/effects/loop.ts` - remains the browser DOM, input, RAF, and test API shell.
+- `packages/cli/module/terminal-cell.ts` - existing terminal frame shape for ANSI rendering.
+- `packages/cli/module/render-frame.ts` - existing pure terminal-frame to ANSI-command projection.
+- `packages/cli/module/write-frame.ts` - existing injected writer boundary and typed write result.
+- `packages/cli/bin/bruff-cli.ts` - current Node entry point to migrate from mock scene to real game frame.
+
+## Test Strategy
+
+- Add Node-safe tests for `@bruff/game/headless` that import only the subpath and assert no browser globals are required.
+- Add pure render tests for `projectRenderCells()` and `projectHeadlessFrame()` using literal state values.
+- Keep existing browser-provider tests for `effects/render.ts`, `effects/frame-step-driver.ts`, and `effects/entry.ts` green.
+- Add focused input tests for terminal arrow CSI sequences in `normaliseKey()`.
+- Add `@bruff/cli` native `node:test` coverage for converting `HeadlessFrame` values to `TerminalFrame` values.
+- Add CLI port tests that simulate terminal arrow key chunks, normalise them through `@bruff/game/headless`, step the state, render a terminal frame, and quit through injected input.
+- Run `CI=true pnpm --filter @bruff/game run format`, `lint`, `typecheck`, and `test`.
+- Run `CI=true pnpm --filter @bruff/cli run format`, `lint`, `typecheck`, and `test`.
+- Run `CI=true pnpm --filter @bruff/arcade run test` after browser entry changes because `@bruff/game` remains the primary browser path.

--- a/specs/prepare-domless-game/spec.md
+++ b/specs/prepare-domless-game/spec.md
@@ -1,0 +1,42 @@
+# Prepare DOMless Game - Spec
+
+## Goal
+
+Decouple the reusable game package surface from DOM and browser evaluation so `@bruff/cli` can run Bruff through Node.js and render it with an ANSI terminal renderer. The browser custom-element flow remains the default and primary import path via `@bruff/game`; the new Node-safe path is an explicit second export target for headless simulation and render data.
+
+## User-Visible Behaviour
+
+- Browser users keep importing `@bruff/game` to define `<bruff-game>` and run the canvas loop.
+- Terminal users can import a new DOM-free game export from `@bruff/game/headless` without evaluating `customElements`, `document`, `window`, `CanvasRenderingContext2D`, `requestAnimationFrame`, or `@bruff/game-element`.
+- `@bruff/cli` can create an initial game state, normalise keyboard input, advance deterministic frames, and project renderable board data through the new public game export.
+- The CLI renderer can render the real game state instead of the current mock scene without deep-importing `packages/game/lib/**`.
+- The CLI can run and debug the headless game from TypeScript source in the pnpm workspace without first compiling `@bruff/game` to `dist`.
+- Terminal arrow escape sequences (`\u001B[A`, `\u001B[B`, `\u001B[C`, and `\u001B[D`) normalise through the same input API as browser arrow key names.
+- Existing replay determinism and browser test-mode behaviour remain unchanged.
+- Existing browser rendering remains the preferred distribution mode; the headless export is additive and opt-in.
+
+## Out Of Scope
+
+- Replacing the browser canvas renderer with terminal rendering.
+- Moving DOM, Canvas, RAF, touch, or test API code out of `packages/game/lib/effects/` except where needed to isolate package exports.
+- Introducing a runtime dependency from `@bruff/game` to `@bruff/cli` or from pure game layers to Node built-ins.
+- Adding a full terminal game loop, resize handling, alternate screen mode, mouse reporting, or save/load UI in this spec.
+- Reworking the tactical rules, board size, enemy AI, replay fixture format, or `GameState.stateVersion`.
+- Publishing a stable external API beyond the monorepo-facing `@bruff/game/headless` target.
+- Requiring `tsx`, `ts-node`, Babel, Vite runtime transforms, or a prebuild step for the CLI development path.
+
+## Open Questions
+
+None. The spec resolves the main ambiguity by making `@bruff/game` the browser-first export and `@bruff/game/headless` the second DOM-free export. The CLI may import only this public subpath, not internal game files.
+
+## Edge Cases
+
+- Importing `@bruff/game/headless` in Node must not fail when `window`, `document`, `customElements`, `HTMLElement`, `CanvasRenderingContext2D`, and `requestAnimationFrame` are absent.
+- Importing `@bruff/game/headless` must not register `<bruff-game>` or start a browser loop.
+- Running `@bruff/cli` in this pnpm workspace must load `@bruff/game/headless` from source through the `bruff-source` export condition, not stale ignored `dist` output.
+- Importing `@bruff/game` in a browser must continue to register `<bruff-game>` and start the current canvas loop exactly once.
+- The headless API must preserve deterministic state transitions for identical seeds and input sequences.
+- Terminal render projection must handle render-only frames with no queued input without incrementing `frameIndex`, matching current game semantics.
+- CLI keyboard input must reuse the same normalisation vocabulary as browser keyboard and touch input.
+- `@bruff/cli` must not depend on browser test providers, Playwright, Vitest, Vite runtime transforms, or DOM globals.
+- Browser bundle output must still include the browser entry and must not require Node built-ins.

--- a/specs/prepare-domless-game/tasks.md
+++ b/specs/prepare-domless-game/tasks.md
@@ -1,0 +1,28 @@
+# Prepare DOMless Game - Tasks
+
+- [x] T1 - Add failing headless export tests in `packages/game/lib/headless/index.test.ts`
+- [x] T2 - Add `./headless` export metadata in `packages/game/package.json`
+- [x] T3 - Add `createHeadlessGame()` in `packages/game/lib/headless/create-headless-game.ts`
+- [x] T4 - Add `stepHeadlessGame()` in `packages/game/lib/headless/step-headless-game.ts`
+- [x] T5 - Add renderer-neutral cell projection tests in `packages/game/lib/render/project-render-cells.test.ts`
+- [x] T6 - Add `projectRenderCells()` in `packages/game/lib/render/project-render-cells.ts`
+- [x] T7 - Refactor `projectRenderCommands()` in `packages/game/lib/render/project-render-commands.ts`
+- [x] T8 - Add headless frame projection tests in `packages/game/lib/headless/project-headless-frame.test.ts`
+- [x] T9 - Add `projectHeadlessFrame()` in `packages/game/lib/headless/project-headless-frame.ts`
+- [x] T10 - Add public headless facade exports in `packages/game/lib/headless/index.ts`
+- [x] T11 - Update library build entries in `packages/game/vite.config.lib.ts`
+- [x] T12 - Update game package guidance in `packages/game/AGENTS.override.md`
+- [x] T13 - Update game usage docs in `packages/game/README.md`
+- [x] T14 - Add CLI dependency on `@bruff/game` in `packages/cli/package.json`
+- [x] T15 - Update CLI package guidance in `packages/cli/AGENTS.override.md`
+- [x] T16 - Add game-to-terminal adapter tests in `packages/cli/module/game-frame.test.ts`
+- [x] T17 - Add `gameFrameToTerminalFrame()` in `packages/cli/module/game-frame.ts`
+- [x] T18 - Refactor CLI port tests in `packages/cli/bin/bruff-cli.test.ts`
+- [x] T19 - Refactor `runBruffCli()` in `packages/cli/bin/bruff-cli.ts`
+- [x] T20 - Remove mock-scene runtime usage from `packages/cli/index.ts`
+- [x] T21 - Verify browser entry behaviour with existing tests in `packages/game/lib/effects/entry.test.ts`
+- [x] T22 - Run package gates named in `specs/prepare-domless-game/acceptance.md`
+- [x] T23 - Add terminal arrow CSI sequence coverage for `normaliseKey()` and CLI input handling
+- [x] T24 - Add the `bruff-source` export condition for native TypeScript workspace consumers
+- [x] T25 - Switch the CLI run, test, and VS Code debug paths to native Node TypeScript source loading without prebuilding `@bruff/game`
+- [x] T26 - Update source-loaded headless and utility imports to use `.ts` specifiers

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
 
     /* Emit */
     "noEmit": true,


### PR DESCRIPTION
 ## Summary

  Implements the `prepare-domless-game` spec by adding a DOM-free public headless game API and wiring the
  terminal CLI to render real game frames instead of the previous mock scene.

  ## Changes

  - Added `@bruff/game/headless` with pure `createHeadlessGame`, `stepHeadlessGame`, and
  `projectHeadlessFrame` exports.
  - Added renderer-neutral `projectRenderCells()` and refactored Canvas render command projection through
  the shared cell projection.
  - Added a built Node export and declaration shim for the headless subpath so Node consumers avoid browser
  entry code and source-only internals.
  - Updated `@bruff/cli` to depend on `@bruff/game/headless`, convert headless frames to terminal frames,
  render the initial game frame, and step the game from terminal movement input.
  - Removed CLI runtime use of the mock scene from the public package entry.
  - Updated package guidance and docs for the new game/CLI boundary.
  - Completed the architecture-doc review and refreshed stale CLI/headless integration documentation.