### PR TITLE
fix: handle sigil emoji variation glyph extraction

### DIFF
--- a/packages/sigil/module/extract-glyphs.test.ts
+++ b/packages/sigil/module/extract-glyphs.test.ts
@@ -18,6 +18,9 @@ const DESCENDER = -200;
 const DECIMAL_PRECISION = 2;
 const EXTRACTED_GLYPH_COUNT = 3;
 const MIXED_INPUT_EXTRACTED_GLYPH_COUNT = 1;
+const VARIATION_SEQUENCE_EXTRACTED_GLYPH_COUNT = 1;
+const ZERO_ADVANCE_WIDTH = 0;
+const FIRST_DRAFT_INDEX = 0;
 
 const pathForAdvanceWidth = (advanceWidth: number): Path => {
   const path = new Path();
@@ -48,6 +51,13 @@ const createNotdefGlyph = (): Glyph =>
     index: NOTDEF_INDEX,
     name: ".notdef",
     path: new Path(),
+  });
+
+const createGlyphWithoutAdvanceWidth = (): Glyph =>
+  new Glyph({
+    name: "space",
+    path: new Path(),
+    unicode: SPACE_CODE_POINT,
   });
 
 const createTestFont = (): Font =>
@@ -96,6 +106,34 @@ describe("extractSigilGlyphs success", () => {
     expectStarDraft(starDraft);
     expect(heartDraft?.defaultName).toBe("u2665");
     expect(checkDraft?.defaultName).toBe("u2713");
+  });
+
+  it("keeps emoji variation sequences as one extracted character", () => {
+    const extractionReport = extractSigilGlyphs(createTestFont(), "♥️♥️");
+    const [heartDraft] = extractionReport.drafts;
+
+    expect(extractionReport.errors).toStrictEqual([]);
+    expect(extractionReport.drafts).toHaveLength(
+      VARIATION_SEQUENCE_EXTRACTED_GLYPH_COUNT,
+    );
+    expect(heartDraft?.defaultName).toBe("u2665");
+    expect(heartDraft?.glyph.unicode).toBe("♥️");
+  });
+
+  it("uses zero advance width when a glyph omits advance width", () => {
+    const font = new Font({
+      ascender: UNITS_PER_EM,
+      descender: DESCENDER,
+      familyName: "Sigil Test",
+      glyphs: [createNotdefGlyph(), createGlyphWithoutAdvanceWidth()],
+      styleName: "Regular",
+      unitsPerEm: UNITS_PER_EM,
+    });
+
+    expect(
+      extractSigilGlyphs(font, " ").drafts[FIRST_DRAFT_INDEX]?.glyph
+        .advanceWidth,
+    ).toBe(ZERO_ADVANCE_WIDTH);
   });
 });
 

--- a/packages/sigil/module/extract-glyphs.ts
+++ b/packages/sigil/module/extract-glyphs.ts
@@ -5,9 +5,11 @@ import type {
   SigilGlyphDraft,
 } from "./glyph-json.js";
 import { codePointKey } from "./code-point-key.js";
+import { distinctGraphemes } from "./unicode-graphemes.js";
 
 const EMPTY_INPUT_LENGTH = 0;
 const GLYPH_PATH_DECIMAL_PLACES = 2;
+const DEFAULT_ADVANCE_WIDTH = 0;
 
 /** Partitioned extraction state for selected glyphs. */
 type GlyphExtractionState = Readonly<{
@@ -25,10 +27,6 @@ const createMissingGlyphError = (character: string): SigilExtractionError => ({
   type: "missing-glyph",
 });
 
-const distinctCharacters = (characters: string): ReadonlyArray<string> => [
-  ...new Set(characters),
-];
-
 const glyphPath = (glyph: Glyph): string =>
   glyph.path.toPathData(GLYPH_PATH_DECIMAL_PLACES);
 
@@ -42,7 +40,7 @@ const glyphDraft = (
   return {
     defaultName: codePointKey(character),
     glyph: {
-      advanceWidth: font.getAdvanceWidth(character, font.unitsPerEm),
+      advanceWidth: glyph.advanceWidth ?? DEFAULT_ADVANCE_WIDTH,
       bounds: {
         x1: bounds.x1,
         x2: bounds.x2,
@@ -107,7 +105,7 @@ export const extractSigilGlyphs = (
   font: Font,
   characters: string,
 ): SigilExtractionResult => {
-  const uniqueCharacters = distinctCharacters(characters);
+  const uniqueCharacters = distinctGraphemes(characters);
   if (uniqueCharacters.length === EMPTY_INPUT_LENGTH) {
     return extractionError([], [emptyInputError]);
   }

--- a/packages/sigil/module/state/character-state.ts
+++ b/packages/sigil/module/state/character-state.ts
@@ -4,10 +4,46 @@ import {
   type SigilSchemaId,
   sigilSchemaNamesByUnicode,
 } from "../sigil-schema-catalog.js";
-import type { ToolSigilState } from "../tool-sigil-state-types.js";
+import type {
+  RequiredGlyphSelection,
+  ToolSigilState,
+} from "../tool-sigil-state-types.js";
 import { extractDrafts } from "../tool-sigil-extract-drafts.js";
 import { extractionCharacters } from "./extraction-characters.js";
 import { schemaOptionById } from "./schema-option.js";
+import { distinctGraphemes, segmentGraphemes } from "../unicode-graphemes.js";
+
+const hasRequiredGraphemeCount = (
+  characters: string,
+  selections: ReadonlyArray<RequiredGlyphSelection>,
+): boolean => segmentGraphemes(characters).length >= selections.length;
+
+const selectionUnicode = (
+  graphemes: ReadonlyArray<string>,
+  selectionIndex: number,
+  fallbackUnicode: string,
+): string => {
+  const grapheme = graphemes[selectionIndex];
+
+  return grapheme === undefined ? fallbackUnicode : grapheme;
+};
+
+/** Maps required glyph selections to typed characters by schema order. */
+const requiredGlyphSelectionsForCharacters = (
+  characters: string,
+  selections: ReadonlyArray<RequiredGlyphSelection>,
+): ReadonlyArray<RequiredGlyphSelection> => {
+  const graphemes = distinctGraphemes(characters);
+
+  if (!hasRequiredGraphemeCount(characters, selections)) {
+    return selections;
+  }
+
+  return selections.map((selection, selectionIndex) => ({
+    ...selection,
+    unicode: selectionUnicode(graphemes, selectionIndex, selection.unicode),
+  }));
+};
 
 /** Updates editable characters.
  * @param state - Current tool state.
@@ -17,12 +53,24 @@ import { schemaOptionById } from "./schema-option.js";
 export const setToolSigilCharacters = (
   state: ToolSigilState,
   characters: string,
-): ToolSigilState => ({
-  ...state,
-  characters,
-  contractIssues: [],
-  ...extractDrafts(state.font, extractionCharacters(characters, state)),
-});
+): ToolSigilState => {
+  const requiredGlyphSelections = requiredGlyphSelectionsForCharacters(
+    characters,
+    state.requiredGlyphSelections,
+  );
+
+  const nextState = {
+    ...state,
+    characters,
+    contractIssues: [],
+    requiredGlyphSelections,
+  };
+
+  return {
+    ...nextState,
+    ...extractDrafts(state.font, extractionCharacters(characters, nextState)),
+  };
+};
 
 /** Updates a required schema glyph.
  * @param state - Current tool state.

--- a/packages/sigil/module/state/extraction-characters.ts
+++ b/packages/sigil/module/state/extraction-characters.ts
@@ -1,8 +1,9 @@
 /* eslint-disable sort-imports -- State split keeps dependency groups readable. */
 import type { ToolSigilState } from "../tool-sigil-state-types.js";
+import { distinctGraphemes } from "../unicode-graphemes.js";
 import { selectedRequiredGlyphCharacters } from "../tool-sigil-required-glyph-selection.js";
 
-/** Combines textarea and selected required glyph characters for extraction.
+/** Deduplicates textarea and selected required characters for extraction.
  * @param characters - Characters requested by the textarea.
  * @param state - Current tool state.
  * @returns Unique characters to extract.
@@ -11,8 +12,6 @@ export const extractionCharacters = (
   characters: string,
   state: ToolSigilState,
 ): string =>
-  [
-    ...new Set(
-      `${characters}${selectedRequiredGlyphCharacters(state.requiredGlyphSelections)}`,
-    ),
-  ].join("");
+  distinctGraphemes(
+    `${characters}${selectedRequiredGlyphCharacters(state.requiredGlyphSelections)}`,
+  ).join("");

--- a/packages/sigil/module/state/tool-sigil-state-selection.test.ts
+++ b/packages/sigil/module/state/tool-sigil-state-selection.test.ts
@@ -18,6 +18,7 @@ import { brand } from "@bruff/utils";
 import { describe, expect, it } from "vitest";
 
 const FIRST_SCHEMA_OPTION_INDEX = 0;
+const SCHEMA_AND_INPUT_GLYPH_READY_TEXT = "Glyphs ready: 6";
 
 describe("ToolSigil state selection", () => {
   it("creates the initial view model", () => {
@@ -74,10 +75,50 @@ describe("ToolSigil loaded font view state", () => {
     expect(selectToolSigilViewModel(loadedState)).toMatchObject({
       downloadDisabled: true,
       fontFileNameText: "component-test.ttf",
-      glyphCountText: "Glyphs ready: 6",
+      glyphCountText: SCHEMA_AND_INPUT_GLYPH_READY_TEXT,
     });
   });
 
+  it("maps required glyph selections to typed characters by schema order", () => {
+    const loadedState = loadCurrentFontState("🌫️🔲🚪👺🤡");
+
+    expect(loadedState.requiredGlyphSelections).toStrictEqual([
+      { name: "floor", unicode: "🌫️" },
+      { name: "wall", unicode: "🔲" },
+      { name: "door", unicode: "🚪" },
+      { name: "player", unicode: "👺" },
+      { name: "enemy", unicode: "🤡" },
+    ]);
+  });
+
+  it("does not append stale schema defaults after all required glyphs are replaced", () => {
+    const viewModel = selectToolSigilViewModel(
+      loadCurrentFontState("🌫️🔲🚪👺🤡"),
+    );
+
+    expect(viewModel.drafts.map((draft) => draft.glyph.unicode)).toStrictEqual([
+      "🌫️",
+      "🔲",
+      "🚪",
+      "👺",
+      "🤡",
+    ]);
+  });
+
+  it("preserves later required selections when replacement characters deduplicate", () => {
+    const loadedState = loadCurrentFontState("★★★★★");
+
+    expect(loadedState.requiredGlyphSelections).toStrictEqual([
+      { name: "floor", unicode: "★" },
+      { name: "wall", unicode: "#" },
+      { name: "door", unicode: "+" },
+      { name: "player", unicode: "@" },
+      { name: "enemy", unicode: "e" },
+    ]);
+  });
+});
+
+describe("ToolSigil schema selection state", () => {
   it("keeps state unchanged for current and unknown schema ids", () => {
     const state = createToolSigilState();
 

--- a/packages/sigil/module/tool-sigil-missing-drafts.ts
+++ b/packages/sigil/module/tool-sigil-missing-drafts.ts
@@ -1,3 +1,4 @@
+import { distinctGraphemes } from "./unicode-graphemes.js";
 import type { Font } from "opentype.js";
 import type { SigilGlyphDraft } from "./glyph-json.js";
 
@@ -34,7 +35,7 @@ export const completeMissingDrafts = (
   characters: string,
   drafts: ReadonlyArray<SigilGlyphDraft>,
 ): ReadonlyArray<SigilGlyphDraft> =>
-  [...characters].map(
+  distinctGraphemes(characters).map(
     (unicode) =>
       drafts.find((draft) => draft.glyph.unicode === unicode) ??
       missingGlyphDraft(font, unicode),

--- a/packages/sigil/module/tool-sigil-required-glyph-selection.test.ts
+++ b/packages/sigil/module/tool-sigil-required-glyph-selection.test.ts
@@ -20,6 +20,13 @@ describe("requiredGlyphCharacterOptions", () => {
       { label: "c", unicode: "c" },
     ]);
   });
+
+  it("keeps emoji variation sequences as one option", () => {
+    expect(requiredGlyphCharacterOptions("🌫️🌫️🤡")).toStrictEqual([
+      { label: "🌫️", unicode: "🌫️" },
+      { label: "🤡", unicode: "🤡" },
+    ]);
+  });
 });
 
 describe("defaultRequiredGlyphSelections", () => {

--- a/packages/sigil/module/tool-sigil-required-glyph-selection.ts
+++ b/packages/sigil/module/tool-sigil-required-glyph-selection.ts
@@ -3,6 +3,7 @@ import type {
   RequiredGlyphSelection,
   RequiredGlyphSelectionView,
 } from "./tool-sigil-state-types.js";
+import { distinctGraphemes } from "./unicode-graphemes.js";
 import type { SigilSchemaOption } from "./sigil-schema-catalog.js";
 
 /**
@@ -14,7 +15,7 @@ import type { SigilSchemaOption } from "./sigil-schema-catalog.js";
 export const requiredGlyphCharacterOptions = (
   characters: string,
 ): ReadonlyArray<RequiredGlyphCharacterOption> =>
-  [...new Set(characters)].map((unicode) => ({
+  distinctGraphemes(characters).map((unicode) => ({
     label: unicode,
     unicode,
   }));

--- a/packages/sigil/module/tool-sigil-state-selectors.ts
+++ b/packages/sigil/module/tool-sigil-state-selectors.ts
@@ -106,6 +106,21 @@ const isValidGlyphMapping = (mapping: SigilGlyphMapping): boolean =>
   findSigilGlyphOption(mapping.groupName, mapping.glyphKey)?.glyph ===
   mapping.glyph;
 
+const selectedRequiredCharacters = (
+  state: ToolSigilState,
+): ReadonlySet<string> =>
+  new Set(state.requiredGlyphSelections.map((selection) => selection.unicode));
+
+const selectedRequiredDrafts = (
+  state: ToolSigilState,
+): ReadonlyArray<SigilGlyphDraft> => {
+  const requiredCharacters = selectedRequiredCharacters(state);
+
+  return state.drafts.filter((draft) =>
+    requiredCharacters.has(draft.glyph.unicode),
+  );
+};
+
 const mappedGlyphErrors = (
   state: ToolSigilState,
 ): ReadonlyArray<SigilExtractionError> =>
@@ -127,21 +142,6 @@ const licenseErrors = (
       (draft) => effectiveLicensesByUnicode[draft.glyph.unicode] === undefined,
     )
     .map((draft) => createMissingLicenseError(draft));
-};
-
-const selectedRequiredCharacters = (
-  state: ToolSigilState,
-): ReadonlySet<string> =>
-  new Set(state.requiredGlyphSelections.map((selection) => selection.unicode));
-
-const selectedRequiredDrafts = (
-  state: ToolSigilState,
-): ReadonlyArray<SigilGlyphDraft> => {
-  const requiredCharacters = selectedRequiredCharacters(state);
-
-  return state.drafts.filter((draft) =>
-    requiredCharacters.has(draft.glyph.unicode),
-  );
 };
 
 const invalidRequiredGlyphSelectionCount = (state: ToolSigilState): number =>

--- a/packages/sigil/module/unicode-graphemes.ts
+++ b/packages/sigil/module/unicode-graphemes.ts
@@ -1,0 +1,15 @@
+const DEFAULT_SEGMENT_LOCALE = undefined;
+
+/** Splits user-entered text into Unicode grapheme clusters. */
+export const segmentGraphemes = (text: string): ReadonlyArray<string> => {
+  const segmenter = new Intl.Segmenter(DEFAULT_SEGMENT_LOCALE, {
+    granularity: "grapheme",
+  });
+
+  return Array.from(segmenter.segment(text), (segment) => segment.segment);
+};
+
+/** Returns distinct grapheme clusters in first-seen order. */
+export const distinctGraphemes = (text: string): ReadonlyArray<string> => [
+  ...new Set(segmentGraphemes(text)),
+];


### PR DESCRIPTION
 Implemented the Sigil fix for stale/default glyph prompts and emoji variation splitting.

 Changed:
 - Added shared grapheme helpers in packages/sigil/module/unicode-graphemes.ts.
 - Updated extraction, missing-draft completion, and required-glyph option generation to use grapheme
   clusters.
 - Updated character state so when all required glyphs are replaced, schema defaults like ., #, +, @, e
   are no longer appended.
 - Added regression tests for:
     - emoji variation sequence options (_)
     - replacing required glyphs with emoji inputs
     - avoiding stale schema defaults after replacement